### PR TITLE
Update data-loss-prevention-policies.md

### DIFF
--- a/microsoft-365/compliance/data-loss-prevention-policies.md
+++ b/microsoft-365/compliance/data-loss-prevention-policies.md
@@ -330,7 +330,8 @@ After you create a label, you can then use that label as a condition in your DLP
     
 By using labels as a condition in your DLP rules, can you selectively enforce protection actions on a specific set of content, locations, or users.
 
-NOTE:  If you specify a retention label as a condition in a DLP policy, and you also include Exchange and/or Teams as a location you will receive the following error:
+> [!NOTE]
+> If you specify a retention label as a condition in a DLP policy and you also include Exchange and/or Teams as a location, you will receive the following error:
 
 ~~~powershell"Protecting labeled content in email and teams messages isn't supported. Either remove the label below or turn off Exchange and Teams as a location."
 ```

--- a/microsoft-365/compliance/data-loss-prevention-policies.md
+++ b/microsoft-365/compliance/data-loss-prevention-policies.md
@@ -329,6 +329,12 @@ After you create a label, you can then use that label as a condition in your DLP
 - You published a label named **Executive Leadership Team - Sensitive** to the Exchange mailboxes and OneDrive accounts of a group of executives. By using this label as a condition in your DLP policy, you can enforce both retention and protection actions on the same subset of content and users. 
     
 By using labels as a condition in your DLP rules, can you selectively enforce protection actions on a specific set of content, locations, or users.
+
+NOTE:  If you specify a retention label as a condition in a DLP policy, and you also include Exchange and/or Teams as a location you will receive the following error:
+
+~~~powershell"Protecting labeled content in email and teams messages isn't supported. Either remove the label below or turn off Exchange and Teams as a location."
+```
+This is because Exchange transport does not evaluate the label metadata during message submission and delivery.  
   
 ![Labels as a condition](media/5b1752b4-a129-4a88-b010-8dcf8a38bb09.png)
 


### PR DESCRIPTION
Using labels as conditions does not explain that Exchange and Teams locations are not currently supported.  Customers receive the following error:

"Protecting labeled content in email and teams messages isn't supported. Either remove the label below or turn off Exchange and Teams as a location."

This is because Exchange transport does not evaluate the label metadata during message submission and delivery.