### PR TITLE
Update controlling-your-data-using-customer-key.md

### DIFF
--- a/microsoft-365/compliance/controlling-your-data-using-customer-key.md
+++ b/microsoft-365/compliance/controlling-your-data-using-customer-key.md
@@ -499,7 +499,7 @@ To set up Customer Key for SharePoint Online and OneDrive for Business, you will
 ### Create a data encryption policy (DEP) for each SharePoint Online and OneDrive for Business geo
 <a name="CreateDEP4SPOODfB"> </a>
 
-A DEP is associated with a set of keys stored in Azure Key Vault. You apply a DEP to all of your data in one geographic location, also called a geo. If you use the multi-geo feature of Office 365 (currently in Preview), you can create one DEP per geo. If you are not using multi-geo, you can create one DEP in Office 365 for use with SharePoint Online and OneDrive for Business. Office 365 will then use the keys identified in the DEP to encrypt your data in that geo. To create the DEP, you need the Key Vault URIs you obtained earlier. See [Obtain the URI for each Azure Key Vault key](controlling-your-data-using-customer-key.md#GetKeyURI) for instructions. 
+A DEP is associated with a set of keys stored in Azure Key Vault. You apply a DEP to all of your data in one geographic location, also called a geo. If you use the multi-geo feature of Office 365, you can create one DEP per geo. If you are not using multi-geo, you can create one DEP in Office 365 for use with SharePoint Online and OneDrive for Business. Office 365 will then use the keys identified in the DEP to encrypt your data in that geo. To create the DEP, you need the Key Vault URIs you obtained earlier. See [Obtain the URI for each Azure Key Vault key](controlling-your-data-using-customer-key.md#GetKeyURI) for instructions. 
   
 Remember! When you create a DEP, you specify two keys that reside in two different Azure Key Vaults. Ensure that these keys are located in two separate Azure regions to ensure geo-redundancy.
   


### PR DESCRIPTION
under "Email messages containing malware removed after delivery"
the licensing we specify is E5 and the like.
however zero hour auto purge is now available to all license, according to:
https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/zero-hour-auto-purge

Shouldn't we update the article?

Also, when I click on the "Zero hour auto purge" hyperlink, I get a not found error.