### PR TITLE
Update mfi-queue-alerts-and-queues.md

### DIFF
--- a/microsoft-365/security/office-365-security/mfi-queue-alerts-and-queues.md
+++ b/microsoft-365/security/office-365-security/mfi-queue-alerts-and-queues.md
@@ -21,7 +21,7 @@ When messages can't be sent from your Office 365 organization to your on-premise
 
 - There have been networking or firewall changes in your on-premises environment.
 
-Office 365 will continue to retry to delivery for 48 hours. After 48 hours, the messages will expire and will be returned to the senders in non-delivery reports (also known as a NDRs or bounce messages).
+Office 365 will continue to retry to delivery for 24 hours. After 24 hours, the messages will expire and will be returned to the senders in non-delivery reports (also known as a NDRs or bounce messages).
 
 If the queued email volume exceeds the pre-defined threshold (the default value is 2000 messages), the alerts will be available in the mail flow dashboard at **Recent alerts**, and admins will receive an email notification (to their alternative email address). To configure the alert threshold, daily notification limit, and/or recipients of the alert, see the **Customize queue alerts** section below.
 


### PR DESCRIPTION
Message Expiration timeout is 24 hours. 

Refer below section from following article: https://docs.microsoft.com/en-us/office365/servicedescriptions/exchange-online-protection-service-description/exchange-online-protection-limits

Message deferral limit Messages in deferral will remain in our queues for 24 hours. Message retry attempts are based on the error type received from the recipient's mail system. Messages are retried every 15 minutes.