### PR TITLE
fixed typo in Germany section of compliance/eu-passport-number.md

### DIFF
--- a/microsoft-365/compliance/eu-passport-number.md
+++ b/microsoft-365/compliance/eu-passport-number.md
@@ -352,7 +352,7 @@ For details, see the section "France Passport Number" in [What the sensitive inf
   
 ## Germany
 
-For details, see the section "Germany Passport Number" in [What the sensitive information types look for](what-the-sensitive-information-types-look-for.md).
+For details, see the section "German Passport Number" in [What the sensitive information types look for](what-the-sensitive-information-types-look-for.md).
   
 ## Greece
 


### PR DESCRIPTION
This fixes #869.

Someone should think about if it's a good idea to add anchors to all section links in this document. This would make navigation within the docs easier.