### PR TITLE
Schema sample for EDM xml file has a typo

### DIFF
--- a/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
+++ b/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
@@ -196,7 +196,7 @@ When you set up your rule package, make sure to correctly reference your .csv fi
   - Name & des Editing the schema criptions: customize as required.
 
 ```xml
-<RulePackage xmlns="https://schemas.microsoft.com/office/2018/edm">
+<RulePackage xmlns="http://schemas.microsoft.com/office/2018/edm">
   <RulePack id="fd098e03-1796-41a5-8ab6-198c93c62b11">
     <Version build="0" major="2" minor="0" revision="0" />
     <Publisher id="eb553734-8306-44b4-9ad5-c388ad970528" />


### PR DESCRIPTION
https://docs.microsoft.com/en-us/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification#define-the-schema-for-your-database-of-sensitive-information

Line 1 in the XML sample file is :
<EdmSchema xmlns="https://schemas.microsoft.com/office/2018/edm">

It should be :
<EdmSchema xmlns="http://schemas.microsoft.com/office/2018/edm">

Using the sample file generates an error 
EDM Failed xml schema definition validation. Error Details : The document namespace is incorrect 'https://schemas.microsoft.com/office/2018/edm' Expected value : 'http://schemas.microsoft.com/office/2018/edm'