### PR TITLE
Changed link from Trust Center > GDPR to the homepage of Trust Center

### DIFF
--- a/microsoft-365/compliance/iso-action-plan.md
+++ b/microsoft-365/compliance/iso-action-plan.md
@@ -68,4 +68,4 @@ Secure personal data at rest and in transit, detect and respond to data breaches
 ## Learn more
 
 - Microsoft Trust Center: [ISO/IEC 27001:2013 Information Security Management Standards](offering-iso-27001.md)
-- [Microsoft Trust Center](https://www.microsoft.com/TrustCenter/Privacy/gdpr/default.aspx)
+- [Microsoft Trust Center](https://www.microsoft.com/trust-center/)


### PR DESCRIPTION
I think this link fits better as the topic isn't primary about GDPR.