### PR TITLE
Updating records page to clarify licensing

### DIFF
--- a/microsoft-365/compliance/records.md
+++ b/microsoft-365/compliance/records.md
@@ -73,6 +73,10 @@ When you create a retention label, you have the option to use the retention labe
 
 3. [Publish](labels.md#how-retention-labels-work-with-retention-label-policies) or [auto-apply](labels.md#applying-a-retention-label-automatically-based-on-conditions) the retention label to SharePoint sites and/or OneDrive accounts.
 
+> [!NOTE]
+> Declaring an item as a record using [retention labels](labels.md) requires an Office 365 Enterprise E5 license or equivalent for each user who has permissions to edit content in this location. Users who have read-only access don't require a license.
+
+
 ### Applying a retention label to content
 
 For Exchange, any user with write-access to the mailbox can apply a record label to an email message. For content in SharePoint and OneDrive, any user in the default Members group (the Contribute permission level) can apply a record label to content. Only a site collection admin can remove or change that record label after it's been applied. As previously explained, a retention label that classifies content as a record can be auto-applied to content.


### PR DESCRIPTION
We've realized that it wasn't clear from the documentation that declaring an item as a record with retention labels requires E5-level licensing. Adding a note to clarify this.