### PR TITLE
Threat trackers wrong description

### DIFF
--- a/microsoft-365/security/office-365-security/threat-trackers.md
+++ b/microsoft-365/security/office-365-security/threat-trackers.md
@@ -50,7 +50,7 @@ Typically Noteworthy trackers will be posted for just a couple of weeks when we 
   
 ### Trending trackers
 
-Trending trackers (formerly called Campaigns) highlight new threats that haven't been seen in your organization's email in the past week.
+Trending trackers (formerly called Campaigns) highlight new threats received in your organization's email in the past week.
   
 ![Example of trending malware campaigns widget](../media/d2ccc1a0-2a1d-4e36-99b5-6766c207772f.png)
   


### PR DESCRIPTION
As the description in https://protection.office.com/threattracker says, "The trending campaigns display dynamic assessments of email threats received your Office 365 service. It is designed to show you trending on received malware, so that you know which threats are increasing and need your focus." So the article is wrong, it's trending malware Received, not that haven't been seen.