### PR TITLE
Update status state for managing jobs-ediscovery20.md

### DIFF
--- a/microsoft-365/compliance/managing-jobs-ediscovery20.md
+++ b/microsoft-365/compliance/managing-jobs-ediscovery20.md
@@ -51,6 +51,6 @@ The following table describes the different status states for jobs.
 | Submission failed | The job submission failed.  You should attempt to rerun the action that triggered the job. |
 | In progress | The job is in progress, you can monitor the progress of the job in the **Jobs** tab. |
 | Successful | The job was successfully completed. The date and time that the job completed is displayed in the **Completed** column on the **Jobs** tab. |
-| Partially successful | The job was partially successful. |
+| Partially successful | The job was partially successful. The job did not find any unindexed data in selected custodian locations.  |
 | Failed | The job failed.  You should attempt to rerun the action that triggered the job. If the job fails a second time, we recommend that you contact Microsoft Support and provide the support information from the job. |
 |||

--- a/microsoft-365/compliance/managing-jobs-ediscovery20.md
+++ b/microsoft-365/compliance/managing-jobs-ediscovery20.md
@@ -51,6 +51,6 @@ The following table describes the different status states for jobs.
 | Submission failed | The job submission failed.  You should attempt to rerun the action that triggered the job. |
 | In progress | The job is in progress, you can monitor the progress of the job in the **Jobs** tab. |
 | Successful | The job was successfully completed. The date and time that the job completed is displayed in the **Completed** column on the **Jobs** tab. |
-| Partially successful | The job was partially successful. The job did not find any unindexed data in selected custodian locations.  |
+| Partially successful | The job was partially successful. This status is typically returned when the job didn't find any unindexed data in some custodian data sources.  |
 | Failed | The job failed.  You should attempt to rerun the action that triggered the job. If the job fails a second time, we recommend that you contact Microsoft Support and provide the support information from the job. |
 |||

--- a/microsoft-365/compliance/managing-jobs-ediscovery20.md
+++ b/microsoft-365/compliance/managing-jobs-ediscovery20.md
@@ -51,6 +51,6 @@ The following table describes the different status states for jobs.
 | Submission failed | The job submission failed.  You should attempt to rerun the action that triggered the job. |
 | In progress | The job is in progress, you can monitor the progress of the job in the **Jobs** tab. |
 | Successful | The job was successfully completed. The date and time that the job completed is displayed in the **Completed** column on the **Jobs** tab. |
-| Partially successful | The job was partially successful. This status is typically returned when the job didn't find any unindexed data in some custodian data sources.  |
+| Partially successful | The job was partially successful. This status is typically returned when the job didn't find any partially indexed data (also called *unindexed data*) in some of the custodian data sources.  |
 | Failed | The job failed.  You should attempt to rerun the action that triggered the job. If the job fails a second time, we recommend that you contact Microsoft Support and provide the support information from the job. |
 |||


### PR DESCRIPTION

We have had a few escalations where customers would like to know why they see a status of "Partially Successful" when performing an advanced eDiscovery search on custodian location.  However, it only indicates description for "Partially Successful" = "The job was partially successful."  When it actually means The job did not find any unindexed data in any of the custodian locations and the job is partially successful.  Would like documentation to be updated to include that in order to avoid more escalations going forward.