### PR TITLE
Fixed typo which may lead to confusion

### DIFF
--- a/microsoft-365/security/office-365-security/troubleshooting-mail-sent-to-office-365.md
+++ b/microsoft-365/security/office-365-security/troubleshooting-mail-sent-to-office-365.md
@@ -165,7 +165,7 @@ Just as important as the way the emails are sent is the content they contain. Wh
 
   `unsubscribe.bulkmailer.com`
 
-  `profiles.excite.com`
+  `profile.excite.com`
 
   `options.yahoo.com`
 


### PR DESCRIPTION
subdomain (`profile` vs `profiles`) didn't match to previous example