### PR TITLE
U/bradhugh/removemoverequest

### DIFF
--- a/microsoft-365/compliance/customer-key-manage.md
+++ b/microsoft-365/compliance/customer-key-manage.md
@@ -137,14 +137,6 @@ Get-MailboxStatistics -Identity <GeneralMailboxOrMailUserIdParameter> | fl IsEnc
 
 The IsEncrypted property returns a value of **true** if the mailbox is encrypted and a value of **false** if the mailbox is not encrypted.
 
-The time to complete mailbox moves depends on the size of the mailbox. If Customer Key hasn't completely encrypted the mailbox after 72 hours from the time you assign a new DEP, initiate a mailbox move. To do this, use the New-MoveRequest cmdlet and provide the alias of the mailbox. For example:
-  
-```powershell
-New-MoveRequest <alias>
-```
-
-For more information about this cmdlet, see [Get-MailboxStatistics](https://docs.microsoft.com/powershell/module/exchange/move-and-migration/new-moverequest?view=exchange-ps).
-
 ### Verify encryption completes for SharePoint Online, OneDrive for Business, and Teams files
 
 Check on the status of encryption by running the Get-SPODataEncryptionPolicy cmdlet as follows:

--- a/microsoft-365/compliance/customer-key-manage.md
+++ b/microsoft-365/compliance/customer-key-manage.md
@@ -137,6 +137,9 @@ Get-MailboxStatistics -Identity <GeneralMailboxOrMailUserIdParameter> | fl IsEnc
 
 The IsEncrypted property returns a value of **true** if the mailbox is encrypted and a value of **false** if the mailbox is not encrypted.
 
+> [!NOTE]
+> The time to encrypt a mailbox depends on the size of the mailbox.
+
 ### Verify encryption completes for SharePoint Online, OneDrive for Business, and Teams files
 
 Check on the status of encryption by running the Get-SPODataEncryptionPolicy cmdlet as follows:


### PR DESCRIPTION
Local moves are being deprecated from Exchange Online.  We need to update the docs to remove the reference to using local move requests to force injection for Customer Key scenarios.

Reference:
https://techcommunity.microsoft.com/t5/exchange-team-blog/disabling-new-moverequest-for-local-mailbox-moves/ba-p/1214776