### PR TITLE
Added instructions for Multi-Geo tenants

### DIFF
--- a/microsoft-365/compliance/sensitivity-labels-sharepoint-onedrive-files.md
+++ b/microsoft-365/compliance/sensitivity-labels-sharepoint-onedrive-files.md
@@ -120,6 +120,8 @@ To enable the preview, use the Set-SPOTenant cmdlet:
 
 1. Using a work or school account that has global administrator or SharePoint admin privileges in Office 365, connect to SharePoint. To learn how, see [Getting started with SharePoint Online Management Shell](https://docs.microsoft.com/powershell/sharepoint/sharepoint-online/connect-sharepoint-online).
 
+Note: Multi-Geo tenants must run the EnableAIPIntegration cmdlet by logging in to each of their geo location's admin centers.
+
 2. Run the following command:
 
     ```PowerShell


### PR DESCRIPTION
For tenants who have multiple instances of SharePoint in different data centers - they must connect to each admin center and enable AIP integration before being able to utilize the feature in each of these geos.