### PR TITLE
Used example external IP address and not an internal address

### DIFF
--- a/microsoft-365/security/office-365-security/set-up-spf-in-office-365-to-help-prevent-spoofing.md
+++ b/microsoft-365/security/office-365-security/set-up-spf-in-office-365-to-help-prevent-spoofing.md
@@ -44,7 +44,7 @@ Gather this information:
 
 - The current SPF TXT record for your custom domain. For instructions, see [Gather the information you need to create Office 365 DNS records](https://docs.microsoft.com/office365/admin/get-help-with-domains/information-for-dns-records).
 
-- IP addresses of all on-premises messaging servers. For example, **192.168.0.1**.
+- External IP addresses of all on-premises messaging servers. For example, **131.107.2.200**.
 
 - Domain names to use for all third-party domains that you need to include in your SPF TXT record. Some bulk mail providers have set up subdomains to use for their customers. For example, the company MailChimp has set up **servers.mcsv.net**.
 


### PR DESCRIPTION
The edit changes the section that says the IP address(es) that you add to the SPF record would look like an internal IP (starting 192 in the original document). The internal IP of the server is not what is needed in the SPF record and it must be the IP address as seen by Exchange Online Protection, aka the external IP address. Added "External" to the the sentence and changed the internal IP example to an example external IP (this IP was used by Microsoft Learning years ago as an example external IP and so is safe to use as is owned by Microsoft.