### PR TITLE
Update configure-the-outbound-spam-policy.md

### DIFF
--- a/microsoft-365/security/office-365-security/configure-the-outbound-spam-policy.md
+++ b/microsoft-365/security/office-365-security/configure-the-outbound-spam-policy.md
@@ -48,7 +48,7 @@ The difference between these two elements isn't obvious when you manage outbound
 
 - When you remove an outbound spam policy from the Security & Compliance Center, the outbound spam filter rule and the associated outbound spam filter policy are removed.
 
-In Exchange Online PowerShell or standalone Exchange Online Protection PowerShell, the difference between outbound spam filter policies and outbound spam filter rules is apparent. You manage outbound spam filter policies by using the **\*-HostedContentFilterPolicy** cmdlets, and you manage outbound spam filter rules by using the **\*-HostedContentFilterRule** cmdlets.
+In Exchange Online PowerShell or standalone Exchange Online Protection PowerShell, the difference between outbound spam filter policies and outbound spam filter rules is apparent. You manage outbound spam filter policies by using the **\*-HostedOutboundSpamFilterPolicy** cmdlets, and you manage outbound spam filter rules by using the **\*-HostedOutboundSpamFilterRule** cmdlets.
 
 - In PowerShell, you create the outbound spam filter policy first, then you create the outbound spam filter rule that identifies the policy that the rule applies to.
 


### PR DESCRIPTION
Verified there is an error in the Configure outbound spam filtering documentation, where it reads “You manage outbound spam filter policies by using the *-HostedContentFilterPolicy cmdlets, and you manage outbound spam filter rules by using the *-HostedContentFilterRule cmdlets.” It should read: “You manage outbound spam filter policies by using the *-HostedOutboundSpamFilterPolicy cmdlets, and you manage outbound spam filter rules by using the *-HostedOutboundSpamFilterRule cmdlets.