### PR TITLE
Update request for shared mailbox requirements

### DIFF
--- a/microsoft-365/compliance/ome-faq.md
+++ b/microsoft-365/compliance/ome-faq.md
@@ -160,7 +160,7 @@ Not at this time.
 
 Yes! Encrypted messages are supported for a shared mailbox.
 
-- Users can open protected mails in a shared mailbox as long as they have full access to the mailbox. Please note that "automapping" is also a requirement for the users to be able to open the content in the shared mailbox.
+- Users can open protected mails in a shared mailbox as long as they have full access to the mailbox. Automapping is also required for users to open content in a shared mailbox.
 
 - Users can view attachments that inherit protection from email when they use Outlook for Windows, Outlook for Mac, and Outlook on the web.
 

--- a/microsoft-365/compliance/ome-faq.md
+++ b/microsoft-365/compliance/ome-faq.md
@@ -160,7 +160,7 @@ Not at this time.
 
 Yes! Encrypted messages are supported for a shared mailbox.
 
-- Users can open protected mails in a shared mailbox as long as they have full access to the same. Please do note that "automapping" is also a requirement for the users to be able to open the content on the shared mailbox.
+- Users can open protected mails in a shared mailbox as long as they have full access to the mailbox. Please note that "automapping" is also a requirement for the users to be able to open the content in the shared mailbox.
 
 - Users can view attachments that inherit protection from email when they use Outlook for Windows, Outlook for Mac, and Outlook on the web.
 

--- a/microsoft-365/compliance/ome-faq.md
+++ b/microsoft-365/compliance/ome-faq.md
@@ -160,7 +160,7 @@ Not at this time.
 
 Yes! Encrypted messages are supported for a shared mailbox.
 
-- Users can open protected mails in a shared mailbox where the shared mailbox received a protected mail as part of a distribution group.
+- Users can open protected mails in a shared mailbox as long as they have full access to the same. Please do note that "automapping" is also a requirement for the users to be able to open the content on the shared mailbox.
 
 - Users can view attachments that inherit protection from email when they use Outlook for Windows, Outlook for Mac, and Outlook on the web.
 


### PR DESCRIPTION
The mentioned statement is not correct in regards to shared mailboxes:
"Users can open protected mails in a shared mailbox where the shared mailbox received a protected mail as part of a distribution group."

The actual requirement (tested in lab and others. for more info on others, please reach me via mail or teams), for this setting to work is for the delegate not only to have full access but also to be automapped and this can be checked via cmd-let Get-MailboxPermission -identity "<shared@contoso.com>" -ReadFromDomainController | FL DelegateListLink" or "(Get-MailboxPermission -identity "<shared@contoso.com>" -ReadFromDomainController).DelegateListLink |sort -unique" to avoid duplicate values

This is the same as the on premises AD. The attribute that tells AD that the user has access to the shared is "MsExchDelegateListLink". On the cloud its via the the "DelegateListLink" that user permissions over shared mailbox sync to Azure AD to later be read by AIP. I can repro in lab anytime

Any questions or doubts please reach me (Manuel Pereira).