### PR TITLE
Fix script for localization

### DIFF
--- a/microsoft-365/compliance/create-sensitivity-labels.md
+++ b/microsoft-365/compliance/create-sensitivity-labels.md
@@ -97,13 +97,12 @@ Settings=@(
 @{key=$Languages[0];Value=$DisplayNames[0];}
 @{key=$Languages[1];Value=$DisplayNames[1];}
 @{key=$Languages[2];Value=$DisplayNames[2];})}
-Set-Label -Identity $Label -LocaleSettings (ConvertTo-Json $DisplayNameLocaleSettings -Depth 3 -Compress)
 $TooltipLocaleSettings = [PSCustomObject]@{LocaleKey='Tooltip';
 Settings=@(
 @{key=$Languages[0];Value=$Tooltips[0];}
 @{key=$Languages[1];Value=$Tooltips[1];}
 @{key=$Languages[2];Value=$Tooltips[2];})}
-Set-Label -Identity $Label -LocaleSettings (ConvertTo-Json $TooltipLocaleSettings -Depth 3 -Compress)
+Set-Label -Identity $Label -LocaleSettings (ConvertTo-Json $DisplayNameLocaleSettings -Depth 3 -Compress),(ConvertTo-Json $TooltipLocaleSettings -Depth 3 -Compress)
 ```
 
 ## Publish sensitivity labels by creating a label policy


### PR DESCRIPTION
The script as provided did not work, as it attempted to run two Set-Label cmdlets that independently set the display name and tooltips. These must be executed in one cmdlet, so I combined them into one Set-Label cmdlet and the script that works as expected.