### PR TITLE
Confusion on case limits

### DIFF
--- a/microsoft-365/compliance/limits-ediscovery20.md
+++ b/microsoft-365/compliance/limits-ediscovery20.md
@@ -3,7 +3,7 @@ title: "Advanced eDiscovery limits"
 f1.keywords:
 - NOCSH
 ms.author: markjjo
-author: markjjo
+author: markjjo 
 manager: laurawi
 audience: Admin
 ms.topic: article


### PR DESCRIPTION
|Total number of documents that can be added to a case (for all review sets in a case).  <br/> |1 million  <br/> |
|Total file size per load set.  <br/> |100 GB  <br/> |
|Total amount of data loaded into a case per day.<br/> |2 TB <br/> |
|Maximum number of loads sets per case.  <br/> |15 <br/> |
|Maximum number of review sets per case.  <br/> |20 <br/> |

If you can only add 15 loads to a case per day (meaning take 15 search results and load them to a Review Set) and the load limit size is 100GB, how will you ever reach the 2TB daily limit OR the max number of review sets per case (20)?  

15 x 100GB = 1.5TB
15 = number of load sets per case (#searches you can add to a review set)
20 = number of Review Sets per case. You can add a single load to multiple review sets but you are still limited by the # of load sets per case at 15. 

Does the total number of documents that can be added to a case include the embedded docs that we pull out upon adding to a Review Set? For instance, my PPT is suddenly 50 files when I add it to a Review Set. We should remain consistent and state either size (5TB for instance) or doc limit for each of these values. 

Thanks Mark!