### PR TITLE
Call out ExO cmdlets when being used

### DIFF
--- a/microsoft-365/compliance/permissions-filtering-for-content-search.md
+++ b/microsoft-365/compliance/permissions-filtering-for-content-search.md
@@ -150,7 +150,7 @@ This example allows members of the "US Discovery Managers" role group to perform
 New-ComplianceSecurityFilter -FilterName USDiscoveryManagers  -Users "US Discovery Managers" -Filters "Mailbox_CountryCode  -eq '840'" -Action All
 ```
 
-This example allows members of the eDiscovery Manager role group to search only the mailboxes of members of the Ottawa Users distribution group. 
+This example allows members of the eDiscovery Manager role group to search only the mailboxes of members of the Ottawa Users distribution group. Get-DistributionGroup in Exchange Online Powershell is used to find the members of Ottawa Users.
   
 ```powershell
 $DG = Get-DistributionGroup "Ottawa Users"
@@ -160,7 +160,7 @@ $DG = Get-DistributionGroup "Ottawa Users"
 New-ComplianceSecurityFilter -FilterName DGFilter  -Users eDiscoveryManager -Filters "Mailbox_MemberOfGroup -eq '$($DG.DistinguishedName)'" -Action Search
 ```
 
-This example prevents any user from deleting content from the mailboxes of members of the Executive Team distribution group.
+This example prevents any user from deleting content from the mailboxes of members of the Executive Team distribution group. Get-DistributionGroup in Exchange Online Powershell is used to find the members of Executive Team.
 
 ```powershell
 $DG = Get-DistributionGroup "Executive Team"

--- a/microsoft-365/compliance/permissions-filtering-for-content-search.md
+++ b/microsoft-365/compliance/permissions-filtering-for-content-search.md
@@ -150,7 +150,7 @@ This example allows members of the "US Discovery Managers" role group to perform
 New-ComplianceSecurityFilter -FilterName USDiscoveryManagers  -Users "US Discovery Managers" -Filters "Mailbox_CountryCode  -eq '840'" -Action All
 ```
 
-This example allows members of the eDiscovery Manager role group to search only the mailboxes of members of the Ottawa Users distribution group. Get-DistributionGroup in Exchange Online Powershell is used to find the members of Ottawa Users.
+This example allows members of the eDiscovery Manager role group to search only the mailboxes of members of the Ottawa Users distribution group. The Get-DistributionGroup cmdlet in Exchange Online PowerShell is used to find the members of the Ottawa Users group.
   
 ```powershell
 $DG = Get-DistributionGroup "Ottawa Users"
@@ -160,7 +160,7 @@ $DG = Get-DistributionGroup "Ottawa Users"
 New-ComplianceSecurityFilter -FilterName DGFilter  -Users eDiscoveryManager -Filters "Mailbox_MemberOfGroup -eq '$($DG.DistinguishedName)'" -Action Search
 ```
 
-This example prevents any user from deleting content from the mailboxes of members of the Executive Team distribution group. Get-DistributionGroup in Exchange Online Powershell is used to find the members of Executive Team.
+This example prevents any user from deleting content from the mailboxes of members of the Executive Team distribution group. The Get-DistributionGroup cmdlet in Exchange Online PowerShell is used to find the members of the Executive Team group.
 
 ```powershell
 $DG = Get-DistributionGroup "Executive Team"


### PR DESCRIPTION
This is a long article and a customer has asked for us to add the need to use Exchange Online Powershell alongside SCC Powershell in the examples where ExO cmdlets are being used. The general need for ExO PS is written at the top of the article, but it would help to call-out where ExO cmdlets are being used in the examples, e.g. examples that call $DG = Get-DistributionGroup. The confusion has been that SCC also contains/contained the same PS cmdlets as ExO, but that those did not work from the SCC side.