### PR TITLE
Replacing outdated checklist & link. #1457

### DIFF
--- a/microsoft-365/compliance/offering-nist-csf.md
+++ b/microsoft-365/compliance/offering-nist-csf.md
@@ -32,7 +32,7 @@ NIST Cybersecurity Framework (CSF) is a voluntary Framework that consists of sta
 
 Learn how to accelerate your NIST Cybersecurity Framework deployment with Compliance Score and our Azure Security and Compliance Blueprint:
 
-- [Overview of the NIST SP 800-53 R4 blueprint sample](https://docs.microsoft.com/en-us/azure/governance/blueprints/samples/nist-sp-800-53-rev4/)
+- [Overview of the NIST SP 800-53 R4 blueprint sample](https://docs.microsoft.com/azure/governance/blueprints/samples/nist-sp-800-53-rev4/)
 - [Learn more about the NIST CSF assessment for Office 365 in Compliance Score](https://techcommunity.microsoft.com/t5/Security-Privacy-and-Compliance/New-NIST-CSF-and-CSA-CCM-assessments-available-in-Compliance/ba-p/218554)
 
 ## Microsoft in-scope cloud services

--- a/microsoft-365/compliance/offering-nist-csf.md
+++ b/microsoft-365/compliance/offering-nist-csf.md
@@ -32,7 +32,7 @@ NIST Cybersecurity Framework (CSF) is a voluntary Framework that consists of sta
 
 Learn how to accelerate your NIST Cybersecurity Framework deployment with Compliance Score and our Azure Security and Compliance Blueprint:
 
-- [Download the Azure Security and Compliance Blueprint - NIST CSF Risk Assessment Checklist](https://servicetrust.microsoft.com/ViewPage/Blueprint?command=Download&downloadType=Document&downloadId=11e61716-11ab-4b11-9a9a-434b33a62ff9&docTab=fc060920-cdb8-11e7-bacf-0bf52b09d912_NIST_CSF_Blueprint)
+- [Overview of the NIST SP 800-53 R4 blueprint sample](https://docs.microsoft.com/en-us/azure/governance/blueprints/samples/nist-sp-800-53-rev4/)
 - [Learn more about the NIST CSF assessment for Office 365 in Compliance Score](https://techcommunity.microsoft.com/t5/Security-Privacy-and-Compliance/New-NIST-CSF-and-CSA-CCM-assessments-available-in-Compliance/ba-p/218554)
 
 ## Microsoft in-scope cloud services


### PR DESCRIPTION
Appears that the CSF checklist referenced in the document is no longer published or available.  Adding a new link to Azure docs page for similar blueprint documentation which is now using Azure Policy to enforce.  