### PR TITLE
Updated "an Microsoft" to "a Microsoft" references

### DIFF
--- a/microsoft-365/admin/admin-overview/about-the-admin-center.md
+++ b/microsoft-365/admin/admin-overview/about-the-admin-center.md
@@ -28,9 +28,9 @@ description: "Use the admin center to set up your organization in the cloud, and
 
 # About the Microsoft 365 admin center
 
-**If you purchased an Microsoft 365 for business plan AND you have admin permissions, you have access to the admin center**. This article is for you!
+**If you purchased a Microsoft 365 for Business plan AND you have admin permissions, you have access to the admin center**. This article is for you!
 
-**If you are a user or have an Microsoft 365 Family plan, you do not have an admin center.** To set up Microsoft 365, go to [Download and install or reinstall Microsoft 365 or Office 2019 on a PC or Mac](https://support.office.com/article/4414eaaf-0478-48be-9c42-23adc4716658.aspx).
+**If you are a user or have a Microsoft 365 Family plan, you do not have an admin center.** To set up Microsoft 365, go to [Download and install or reinstall Microsoft 365 or Office 2019 on a PC or Mac](https://support.office.com/article/4414eaaf-0478-48be-9c42-23adc4716658.aspx).
 
 You use the admin center to set up your organization in the cloud, manage users, manage subscriptions, and much more. In this article, learn how to get to the admin center and learn about available features and settings.
 
@@ -72,7 +72,7 @@ Here are the features and settings you'll find in the left-hand navigation of th
 |-----|-----|
 |**Home** <br/> |This is the landing page in the admin center. You'll see where to manage users, billing, service health, and reports.  <br/> |
 |**Users** <br/> |Create and manage users in your organization, like employees or students. You can also set their permission level or reset their passwords.  <br/> |
-|**Groups** <br/> |Create and manage groups in your organization, such as an Microsoft 365 group, distribution group, security group, or shared mailbox. Learn how to [create](../create-groups/create-groups.md) and [manage](../create-groups/manage-groups.md) groups.  <br/> |
+|**Groups** <br/> |Create and manage groups in your organization, such as a Microsoft 365 group, distribution group, security group, or shared mailbox. Learn how to [create](../create-groups/create-groups.md) and [manage](../create-groups/manage-groups.md) groups.  <br/> |
 |**Resources** <br/> |Create and manage resources, like a SharePoint site collection. Learn how to [create site collections](https://docs.microsoft.com/sharepoint/create-site-collection).  <br/> |
 |**Billing** <br/> |View, purchase, or cancel subscriptions for your organization. View past billing statements or view the number of assigned licenses to individual users. Learn how to [manage billing](../../commerce/index.yml).  <br/> |
 |**Support** <br/> | View existing service requests or create new ones. Learn more in [Contact support for business products - Admin Help](../contact-support-for-business-products.md). |
@@ -90,7 +90,7 @@ Here are the features and settings you'll find in the left-hand navigation of th
 
 - See activity reports: [Activity Reports](../activity-reports/activity-reports.md)
 
-- [Create an Microsoft 365 group ](../create-groups/create-groups.md)
+- [Create a Microsoft 365 group ](../create-groups/create-groups.md)
 
 - [Manage a Microsoft 365 group](../create-groups/manage-groups.md)
 

--- a/microsoft-365/admin/admin-overview/about-the-admin-center.md
+++ b/microsoft-365/admin/admin-overview/about-the-admin-center.md
@@ -28,7 +28,7 @@ description: "Use the admin center to set up your organization in the cloud, and
 
 # About the Microsoft 365 admin center
 
-**If you purchased a Microsoft 365 for Business plan AND you have admin permissions, you have access to the admin center**. This article is for you!
+**If you purchased a Microsoft 365 for business plan AND you have admin permissions, you have access to the admin center**. This article is for you!
 
 **If you are a user or have a Microsoft 365 Family plan, you do not have an admin center.** To set up Microsoft 365, go to [Download and install or reinstall Microsoft 365 or Office 2019 on a PC or Mac](https://support.office.com/article/4414eaaf-0478-48be-9c42-23adc4716658.aspx).
 


### PR DESCRIPTION
Hi team! I was reading this article and noticed several references to "an Microsoft 365" instead of the proper grammar of "a Microsoft 365". Was likely due to a Find&Replace during the Office 365 to Microsoft 365 rebranding. Would probably behoove someone to run a check across the whole stack of pages? How can I help?