### PR TITLE
Cleaned up messy sentence

### DIFF
--- a/microsoft-365/compliance/encryption-sensitivity-labels.md
+++ b/microsoft-365/compliance/encryption-sensitivity-labels.md
@@ -344,7 +344,7 @@ Use this configuration only when you do not need to restrict who can open the pr
 
 5. Select **Choose permissions from present or custom**.
 
-6. On the **Choose permissions from present or custom** pane, select the dropdown box, select **Viewer**permissions you want, and then select **Save**.
+6. On the **Choose permissions from present or custom** pane, select the dropdown box, select the permissions you want, and then select **Save**.
 
 7. Back on the **Assign Permissions** pane, select **Save**.
 


### PR DESCRIPTION
Removed the Viewer hint, which was a copy and paste error probably.

The step is now in accordance with Example 3, where the guide also does not specify in detail which permission to choose.