### PR TITLE
Updated U.K. Drivers License

### DIFF
--- a/microsoft-365/compliance/sensitive-information-type-entity-definitions.md
+++ b/microsoft-365/compliance/sensitive-information-type-entity-definitions.md
@@ -11983,7 +11983,7 @@ Combination of 18 letters and digits in the specified format
 - One digit 
 - Five digits in the date format MMDDY for date of birth (7th character is incremented by 50 if driver is female, i.e. 51 to 62 instead of 01 to 12)
 - Two letters (not case sensitive) or the digit "9" in place of a letter 
-- Five digits
+- Five digits or letters
 
 ### Checksum
 


### PR DESCRIPTION
The last 5 characters of a UK driving license are in many cases both numbers and letters. Drivers licenses in this format do still match correctly.