### PR TITLE
Update to permissions for disposition

### DIFF
--- a/microsoft-365/compliance/disposition.md
+++ b/microsoft-365/compliance/disposition.md
@@ -30,7 +30,7 @@ To manage disposition reviews and confirm that records have been deleted, you mu
 
 ### Permissions for disposition
 
-To successfully access the **Disposition** tab in the Microsoft 365 compliance center, you must be members of the **Disposition Management** role and the **View-Only Audit Logs** role. We recommend creating a new role group called **Disposition Reviewers**, and add these two roles to that role group. 
+To successfully access the **Disposition** tab in the Microsoft 365 compliance center, you must be members of the **Disposition Management** role and the **View-Only Audit Logs** role. We recommend creating a new role group called **Disposition Reviewers**, and add these two roles to that role group. Even if you are a **Global Admin** user, you will have to be part of the **Disposition Management** role for you to access the disposition tab.
 
 Specific to the **View-Only Audit Logs** role:
 


### PR DESCRIPTION
The existing documentation doesn't explicitly call out that a Global Admin user should also be part of the 'Disposition Management' role to see the disposition management in the M365 Compliance Center. This is a big source of confusion and there are customer escalations around this. I am discussing with Roberto on the rationale behind the current design. But, lets have a temporary update to the documentation so that customers are aware.