### PR TITLE
Update dlp-microsoft-teams.md Note section

### DIFF
--- a/microsoft-365/compliance/dlp-microsoft-teams.md
+++ b/microsoft-365/compliance/dlp-microsoft-teams.md
@@ -21,7 +21,7 @@ description: "You can now apply DLP policies to Microsoft Teams chats and channe
 
 > [!NOTE]
 > Data loss prevention capabilities were recently added to Microsoft Teams chat and channel messages for users licensed for Office 365 Advanced Compliance, which is available as a standalone option and is included in Office 365 E5 and Microsoft 365 E5 Compliance. Office 365 and Microsoft 365 E3 include DLP protection for SharePoint Online, OneDrive, and Exchange Online. This also includes files that are shared through Teams because Teams uses SharePoint Online and OneDrive to share files.
-Support for DLP protection in Teams Chat requires E5.
+Support for DLP protection in Teams Chat is not included in E3.
 To learn more about licensing requirements, see [Microsoft 365 Tenant-Level Services Licensing Guidance](https://docs.microsoft.com/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance).
 
 ## Overview of DLP for Microsoft Teams


### PR DESCRIPTION
Note section mentions that "Support for DLP protection in Teams Chat requires E5". But Office 365 Advanced Compliance allows customers to Teams Chat DLP as well.
To remove customers confusion, update the line to "Support for DLP protection in Teams Chat is not included in E3." because previous sentence before this line is talking about Teams file share DLP. I think that this line wanted to say Teams Chat DLP is not included in E3, even E3 includes Teams file share DLP. @chrfox