### PR TITLE
Reflecting Changes to Service in config 95

### DIFF
--- a/microsoft-365/managed-desktop/get-started/project-visio.md
+++ b/microsoft-365/managed-desktop/get-started/project-visio.md
@@ -23,26 +23,17 @@ Admins should verify that they meet these prerequisites:
 - **Company Portal** -  The Company Portal must be available in your tenant for your users to install these applications. If the Company Portal isn’t deployed in your tenant, see [Company Portal](company-portal.md).
 
 ## Deploy Project and Visio for Microsoft Managed Desktop devices
-After you submit your support request, Microsoft Managed Desktop will create three Azure AD groups and three application deployments through Microsoft Intune to deploy the apps to your tenant.  
+Microsoft Managed Desktop will add Microsoft Project and Microsoft Visio as two Win32 Applications in Microsoft Intune. We will also create two groups in Azure Active Directory which will be assigned to the coresponding application with the "Available" intent. 
 
 **To deploy Project and Visio**
-1. **File a support request** IT administrators need to file a support request to make these applications available their users. For information on contacting Microsoft Managed Desktop, see [Admin support for Microsoft Managed Desktop](../working-with-managed-desktop/admin-support.md).
-2. **Assign users to new Azure AD groups** Microsoft Managed Desktop will create 3 Azure AD groups in your tenant and 3 corresponding application deployments. IT admins need to assign the users to the appropriate groups.
-
->[!NOTE]
->Assign users to only one of these Azure AD groups. 
+Add the user to the appropriate group and the application will become available in the Company Portal. It may take a few minutes to sync, but then your users can install the apps from Company Portal. 
 
 Azure AD Group name | Which users to assign?   
  --- | ---
 Modern Workplace-Office-Project_Install | Users needing Project
 Modern Workplace-Office-Visio_Install | Users needing Visio
 
-Once assigned to these groups, applications will be available in the Company Portal. It may take a few minutes to sync, but then your users can install the apps from Company Portal. 
-
 ## Communicate changes
 It’s important for IT administrators to let their users know how to install Project and Visio. This includes: 
 - Notifying users when these applications are available to them. 
 - Instructions on how to install these applications from the Company Portal.
-
->[!NOTE]
->Users must close all Office applications before installing Microsoft Project or Microsoft Visio from Company Portal. 


### PR DESCRIPTION
With config 95 IT admins no longer need to request that Project and Visio are added to the service since it will be done automatically. I have adjusted the docs to reflect that and adjusted the workflow accordingly.