### PR TITLE
Update create-safe-sender-lists-in-office-365.md

### DIFF
--- a/microsoft-365/security/office-365-security/create-safe-sender-lists-in-office-365.md
+++ b/microsoft-365/security/office-365-security/create-safe-sender-lists-in-office-365.md
@@ -121,7 +121,7 @@ For example, suppose that Blue Yonder Airlines has hired Margie's Travel to send
 
 - The `5322.From` address is blueyonder@news.blueyonderairlines.com, which is what you'll see in Outlook.
 
-Safe sender lists and safe domain lists in anti-spam policies in EOP inspect both the `5321.MailFrom` and `5322.From` addresses. Outlook Safe Senders only uses the `5322.From` address.
+Safe sender lists and safe domain lists in anti-spam policies in EOP inspect only the `5322.From` addresses. This is similar to Outlook Safe Senders which also uses only the `5322.From` address.
 
 To prevent this message from being filtered, you can take the following steps:
 


### PR DESCRIPTION
based on https://o365exchange.visualstudio.com/_search?text=5321%20%22allow%20list%22&type=workitem&pageSize=25 , Antispam policy safe sender and domain only works against P2 address(5322) and not P1 (5321).