### PR TITLE
FIxed two typos in sample scripts

### DIFF
--- a/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
+++ b/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
@@ -364,13 +364,13 @@ To upload your rule package, do the following steps:
 3. Use the following syntax:
 
 ```powershell
-New-DlpSensitiveInformationTypeRulePackage -FileData (Get-Content -Path "PathToUnicodeXMLFile" -Encoding Byte) -ReadCount 0
+New-DlpSensitiveInformationTypeRulePackage -FileData (Get-Content -Path "PathToUnicodeXMLFile" -Encoding Byte -ReadCount 0)
 ```
 
     This example uploads the Unicode XML file named MyNewRulePack.xml from C:\My Documents.
 
 ```powershell
-New-DlpSensitiveInformationTypeRulePackage -FileData (Get-Content -Path "C:\My Documents\MyNewRulePack.xml" -Encoding Byte) -ReadCount 0
+New-DlpSensitiveInformationTypeRulePackage -FileData (Get-Content -Path "C:\My Documents\MyNewRulePack.xml" -Encoding Byte -ReadCount 0)
 ```
 
     For detailed syntax and parameter information, see [New-DlpSensitiveInformationTypeRulePackage](https://docs.microsoft.com/powershell/module/exchange/new-dlpsensitiveinformationtyperulepackage).


### PR DESCRIPTION
The Readcount parameter must be within the parenthesis, since it is not a parameter of the New-DLPSensitivieInfoType commandlet but of Get-Content. This typo was in the first two samples, and not in the third one which was correct.