### PR TITLE
Private channel retention for TEams

### DIFF
--- a/microsoft-365/compliance/create-retention-policies.md
+++ b/microsoft-365/compliance/create-retention-policies.md
@@ -47,7 +47,7 @@ These permissions are required only to create and apply a retention policy. The 
     
     For Microsoft Teams: 
     - You must select the option to choose specific locations if you want to delete or retain Teams channel messages or Team chats. When you select either of these options as locations, the other locations are automatically excluded because a retention policy that includes this Teams data can't include other locations. 
-    - Note that for **Teams channel messages**, message from standard channels but not [private channels](https://docs.microsoft.com/microsoftteams/private-channels) are included. Messages from private channels are included for users as group chats when you select the **Teams chats** location.
+    - Note that for **Teams channel messages**, message from standard channels but not [private channels](https://docs.microsoft.com/microsoftteams/private-channels) are included.
     
     For more information about choosing between a retention policy for the organization or for specific locations, see [Applying a retention policy to an entire organization or specific locations](#applying-a-retention-policy-to-an-entire-organization-or-specific-locations) on this page.
     


### PR DESCRIPTION
Removed part of the article that suggested retention for private channel works. Retention is not supported for Private channels.