### PR TITLE
Retention delete latency

### DIFF
--- a/microsoft-365/compliance/retention-policies-teams.md
+++ b/microsoft-365/compliance/retention-policies-teams.md
@@ -3,6 +3,7 @@ title: "Learn about retention policies for Teams"
 f1.keywords:
 - NOCSH
 ms.author: cabailey
+ms.author: anwara
 author: cabailey
 manager: laurawi
 ms.date: 
@@ -112,10 +113,10 @@ We're continuously working on optimizing retention functionality in Teams. In th
 
 - **Teams messages in private channels aren't included when you configure a retention policy for Teams channel messages**. Instead, messages from private channels are included for the users as group chats with the **Teams chats** option. 
     
-- **Teams may take up to three days to clean up expired messages**. A retention policy applied to Teams will delete chat and channel messages when the retention period expires. However, it may take up to three days to clean up these messages and permanently delete them. Also, chat and channel messages will be searchable with eDiscovery tools during the time after the retention period expires and when messages are permanently deleted.
+- **Teams may take up to seven days to clean up expired messages**. A retention policy applied to Teams will delete chat and channel messages when the retention period expires. However, it may take up to seven days to clean up these messages and permanently delete them. Also, chat and channel messages will be searchable with eDiscovery tools during the time after the retention period expires and when messages are permanently deleted.
     
    > [!NOTE]
-   > It used to be true that a retention policy couldn't delete Teams content that's less than 30 days old, but we've removed this limitation. Now the retention period for Teams content can be any number of days you choose and as short as one day. If you do have a retention period of one day, it will take up to three days after the retention period expires before messages are permanently deleted.
+   > It used to be true that a retention policy couldn't delete Teams content that's less than 30 days old, but we've removed this limitation. Now the retention period for Teams content can be any number of days you choose and as short as one day. If you do have a retention period of one day, it will take up to seven days after the retention period expires before messages are permanently deleted.
 
 - **Incorrect display issue in Outlook**. If you create retention policies for Skype or Teams locations, one of those policies is shown as the default folder policy when a user views the properties of a mailbox folder in the Outlook desktop client. This is an incorrect display issue in Outlook and [a known issue](https://support.microsoft.com/help/4491013/outlook-client-displays-teams-or-skype-for-business-retention-policies). What should be displayed as the default folder policy is the mailbox retention policy that's applied to the folder. The Skype or Teams retention policy is not applied to the user's mailbox.
 


### PR DESCRIPTION
Retention on Teams takes seven days to delete content, not three. The same has been updated in Teams documentation

https://docs.microsoft.com/en-us/microsoftteams/retention-policies