### PR TITLE
Update add-or-remove-members-from-groups.md

### DIFF
--- a/microsoft-365/admin/create-groups/add-or-remove-members-from-groups.md
+++ b/microsoft-365/admin/create-groups/add-or-remove-members-from-groups.md
@@ -54,6 +54,9 @@ In Microsoft 365, group members typically create their own groups, add themselve
 
 ::: moniker-end
 
+> [!NOTE]
+> You need to be a Global admin or a Groups admin to make changes to a group in the M365 admin center.
+
 ::: moniker range="o365-germany"
 
 1. In the <a href="https://go.microsoft.com/fwlink/p/?linkid=848041" target="_blank">admin center</a>, go to the **Groups** \> **Groups** page.  

--- a/microsoft-365/admin/create-groups/add-or-remove-members-from-groups.md
+++ b/microsoft-365/admin/create-groups/add-or-remove-members-from-groups.md
@@ -55,7 +55,7 @@ In Microsoft 365, group members typically create their own groups, add themselve
 ::: moniker-end
 
 > [!NOTE]
-> You need to be a Global admin or a Groups admin to make changes to a group in the M365 admin center.
+> You need to be a global admin or a groups admin to make changes to a group in the Microsoft 365 admin center.
 
 ::: moniker range="o365-germany"
 


### PR DESCRIPTION
added a note to the document to stress the fact that only global admin or group admins can make changes to a group via the 365 admin center.