### PR TITLE
Removed "Number of Groups a user can be a member of" from office-365-groups.md

### DIFF
--- a/microsoft-365/admin/create-groups/office-365-groups.md
+++ b/microsoft-365/admin/create-groups/office-365-groups.md
@@ -71,7 +71,6 @@ The following limits apply to Microsoft 365 Groups:
 |Groups a user can create|250|
 |Groups an admin can create|Up to default tenant limit of 500K|
 |Number of members|More than 1,000, though only 1,000 can access the Group conversations concurrently. <br>Users might notice delays when accessing the calendar and conversations in very large groups in Outlook.|
-|Number of Groups a user can be a member of|1,000|
 |File storage|1 Terabyte + 10 GB per subscribed user + any additional storage purchased. You can purchase an unlimited amount of additional storage.|
 |Group Mailbox size|50 GB|
 

--- a/microsoft-365/admin/create-groups/office-365-groups.md
+++ b/microsoft-365/admin/create-groups/office-365-groups.md
@@ -71,6 +71,7 @@ The following limits apply to Microsoft 365 Groups:
 |Groups a user can create|250|
 |Groups an admin can create|Up to default tenant limit of 500K|
 |Number of members|More than 1,000, though only 1,000 can access the Group conversations concurrently. <br>Users might notice delays when accessing the calendar and conversations in very large groups in Outlook.|
+|Number of Groups a user can be a member of|7,000|
 |File storage|1 Terabyte + 10 GB per subscribed user + any additional storage purchased. You can purchase an unlimited amount of additional storage.|
 |Group Mailbox size|50 GB|
 


### PR DESCRIPTION
Closes https://github.com/MicrosoftDocs/microsoft-365-docs/issues/2349.

Same as https://github.com/MicrosoftDocs/microsoft-365-docs/issues/2382.

"A user can be a member of any number of groups":
https://docs.microsoft.com/azure/active-directory/users-groups-roles/directory-service-limits-restrictions

@MikePlumleyMSFT Could you kindly confirm? Thanks!