### PR TITLE
Update find-and-release-quarantined-messages-as-a-user.md

### DIFF
--- a/microsoft-365/security/office-365-security/find-and-release-quarantined-messages-as-a-user.md
+++ b/microsoft-365/security/office-365-security/find-and-release-quarantined-messages-as-a-user.md
@@ -33,9 +33,9 @@ As a user, you can view, release, and delete quarantined messages where you are 
 
 - Admins can configure how long messages are kept in quarantine before they're permanently deleted (anti-spam policies). Messages that have expired from quarantine are unrecoverable. For more information, see [Configure anti-spam policies in EOP](configure-your-spam-filter-policies.md).
 
-- Admins can also [enable end-user spam notifications](configure-your-spam-filter-policies.md#configure-end-user-spam-notifications) in anti-spam policies. Users can release spam quarantined messages but not phish quarantined messages directly from these notifications. For more information, see [End-user spam notifications in EOP](use-spam-notifications-to-release-and-report-quarantined-messages.md).
+- Admins can also [enable end-user spam notifications](configure-your-spam-filter-policies.md#configure-end-user-spam-notifications) in anti-spam policies. Users can release quarantined spam messages but not quarantined phishing messages directly from these notifications. For more information, see [End-user spam notifications in EOP](use-spam-notifications-to-release-and-report-quarantined-messages.md).
 
-- Messages that were quarantined for high confidence phishing, malware, or by mail flow rules (also known as transport rules) are only available to admins. Phish messages can be reviewed by users, but only Admins can release. For more information, see [Manage quarantined messages and files as an admin in EOP](manage-quarantined-messages-and-files.md).
+- Messages that were quarantined for high confidence phishing, malware, or by mail flow rules (also known as transport rules) are only available to admins. Phishing messages can be reviewed by users, but only released by admins. For more information, see [Manage quarantined messages and files as an admin in EOP](manage-quarantined-messages-and-files.md).
 
 - You can only release a message and report it as a false positive (not junk) once.
 

--- a/microsoft-365/security/office-365-security/find-and-release-quarantined-messages-as-a-user.md
+++ b/microsoft-365/security/office-365-security/find-and-release-quarantined-messages-as-a-user.md
@@ -35,7 +35,7 @@ As a user, you can view, release, and delete quarantined messages where you are 
 
 - Admins can also [enable end-user spam notifications](configure-your-spam-filter-policies.md#configure-end-user-spam-notifications) in anti-spam policies. Users can release spam quarantined messages but not phish quarantined messages directly from these notifications. For more information, see [End-user spam notifications in EOP](use-spam-notifications-to-release-and-report-quarantined-messages.md).
 
-- Messages that were quarantined for high confidence phishing, malware, or by mail flow rules (also known as transport rules) are only available to admins. Phish messages can be reviewed and released by users. For more information, see [Manage quarantined messages and files as an admin in EOP](manage-quarantined-messages-and-files.md).
+- Messages that were quarantined for high confidence phishing, malware, or by mail flow rules (also known as transport rules) are only available to admins. Phish messages can be reviewed by users, but only Admins can release. For more information, see [Manage quarantined messages and files as an admin in EOP](manage-quarantined-messages-and-files.md).
 
 - You can only release a message and report it as a false positive (not junk) once.
 


### PR DESCRIPTION
corrected the statement "hish messages can be reviewed by users, but only Admins can release."