### PR TITLE
Update create-retention-policies.md

### DIFF
--- a/microsoft-365/compliance/create-retention-policies.md
+++ b/microsoft-365/compliance/create-retention-policies.md
@@ -145,7 +145,7 @@ To verify the syntax for your tenant and identify URLs for users, see [Get a lis
 
 To retain or delete content for a Microsoft 365 group (formerly Office 365 group), use the **Office 365 groups** location. Even though a Microsoft 365 group has an Exchange mailbox, a retention policy that includes the entire **Exchange email** location won't include content in Microsoft 365 group mailboxes. In addition, although the **Exchange email** location initially allows you to specify a group mailbox to be included or excluded, when you try to save the retention policy, you receive an error that "RemoteGroupMailbox" is not a valid selection for the Exchange location.
 
-A retention policy applied to a Microsoft 365 group includes both the group mailbox and site. A retention policy applied to a Microsoft 365 group protects the resources created by a Microsoft 365 group, which includes Microsoft Teams.
+A retention policy applied to a Microsoft 365 group includes both the group mailbox and site. A retention policy applied to a Microsoft 365 group protects the resources created by a Microsoft 365 group, which includes files in Microsoft Teams.However, the only way to manage Teams conversations is through the Teams Conversations location.
 
 ### Configuration information for Skype for Business
 


### PR DESCRIPTION
added a line to the configuration information for microsoft 365 groups that the only way to manage teams conversations is to apply policy on teams conversations location and not on m365 groups.