### PR TITLE
Update secure-your-business-data.md

### DIFF
--- a/microsoft-365/admin/security-and-compliance/secure-your-business-data.md
+++ b/microsoft-365/admin/security-and-compliance/secure-your-business-data.md
@@ -160,7 +160,7 @@ To create a mail transport rule, view a [short training video](https://support.m
 |Name  <br/> |Anti-ransomware rule: warn users  <br/> |Anti-ransomware rule: block file types  <br/> |
 |Apply this rule if . . .  <br/> |Any attachment . . . file extension matches . . .  <br/> |Any attachment . . . file extension matches . . .  <br/> |
 |Specify words or phrases  <br/> |Add these file types:  <br/> dotm, docm, xlsm, sltm, xla, xlam, xll, pptm, potm, ppam, ppsm, sldm  <br/> |Add these file types:  <br/> ade, adp, ani, bas, bat, chm, cmd, com, cpl, crt, hlp, ht, hta, inf, ins, isp, job, js, jse, lnk, mda, mdb, mde, mdz, msc, msi, msp, mst, pcd, reg, scr, sct, shs, url, vb, vbe, vbs, wsc, wsf, wsh, exe, pif  <br/> |
-|Do the following . . .  <br/> |Notify the recipient with a message  <br/> |Block the message . . . reject the message and include an explanation  <br/> |
+|Do the following . . .  <br/> |Prepend a Disclaimer  <br/> |Block the message . . . reject the message and include an explanation  <br/> |
 |Provide message text  <br/> |Do not open these types of files—unless you were expecting them—because the files may contain malicious code and knowing the sender isn't a guarantee of safety.  <br/> ||
    
 > [!TIP]

--- a/microsoft-365/admin/security-and-compliance/secure-your-business-data.md
+++ b/microsoft-365/admin/security-and-compliance/secure-your-business-data.md
@@ -160,7 +160,7 @@ To create a mail transport rule, view a [short training video](https://support.m
 |Name  <br/> |Anti-ransomware rule: warn users  <br/> |Anti-ransomware rule: block file types  <br/> |
 |Apply this rule if . . .  <br/> |Any attachment . . . file extension matches . . .  <br/> |Any attachment . . . file extension matches . . .  <br/> |
 |Specify words or phrases  <br/> |Add these file types:  <br/> dotm, docm, xlsm, sltm, xla, xlam, xll, pptm, potm, ppam, ppsm, sldm  <br/> |Add these file types:  <br/> ade, adp, ani, bas, bat, chm, cmd, com, cpl, crt, hlp, ht, hta, inf, ins, isp, job, js, jse, lnk, mda, mdb, mde, mdz, msc, msi, msp, mst, pcd, reg, scr, sct, shs, url, vb, vbe, vbs, wsc, wsf, wsh, exe, pif  <br/> |
-|Do the following . . .  <br/> |Prepend a Disclaimer  <br/> |Block the message . . . reject the message and include an explanation  <br/> |
+|Do the following . . .  <br/> |Prepend a disclaimer  <br/> |Block the message . . . reject the message and include an explanation  <br/> |
 |Provide message text  <br/> |Do not open these types of files—unless you were expecting them—because the files may contain malicious code and knowing the sender isn't a guarantee of safety.  <br/> ||
    
 > [!TIP]


### PR DESCRIPTION
Setting the "Notify" action for the transport rule "Anti-ransomware rule: warn users" results in double-up emails that confuse recipients and do not provide a clear message about the action required. Instead changed it to '"Prepend a Disclaimer" so that the warning is stamped onto the original email message, making it clear what content the warning applies to, and providing a more familiar experience to the user.