### PR TITLE
Update back-up-data-before-switching-plans.md

### DIFF
--- a/microsoft-365/commerce/subscriptions/back-up-data-before-switching-plans.md
+++ b/microsoft-365/commerce/subscriptions/back-up-data-before-switching-plans.md
@@ -29,7 +29,7 @@ description: "Backup Outlook, OneDrive, Yammer, and SharePoint content before ch
 If a user will be switched to another subscription that has fewer data-related services or a user leaves the organization, a copy of their data that's stored in Microsoft 365 can be downloaded before they are switched to the new subscription.
 
  > [!NOTE]
- > It's not required to back up data when you switch to another subscription that provides more and same services. User data will always be preserved and no action need be taken for any individual service that is present in both  expiring and replacement subscription assigned to the same user.
+ > It's not required to back up data when you switch to another subscription that provides the same or more services. User data will always be preserved and no action needs to be taken for any individual service that is present in both the expiring and replacement subscriptions assigned to the same user.
 
   
 ## Save a copy of Outlook information

--- a/microsoft-365/commerce/subscriptions/back-up-data-before-switching-plans.md
+++ b/microsoft-365/commerce/subscriptions/back-up-data-before-switching-plans.md
@@ -28,9 +28,7 @@ description: "Backup Outlook, OneDrive, Yammer, and SharePoint content before ch
 
 If a user will be switched to another subscription that has fewer data-related services or a user leaves the organization, a copy of their data that's stored in Microsoft 365 can be downloaded before they are switched to the new subscription.
 
- > [!NOTE]
- > It's not required to back up data when you switch to another subscription that provides the same or more services. User data will always be preserved and no action needs to be taken for any individual service that is present in both the expiring and replacement subscriptions assigned to the same user.
-
+If you're moving a user to a subscription that has the same or more services, you don't need to back up user data. See [Move users to a different subscription](https://docs.microsoft.com/microsoft-365/commerce/subscriptions/move-users-different-subscription) .
   
 ## Save a copy of Outlook information
 

--- a/microsoft-365/commerce/subscriptions/back-up-data-before-switching-plans.md
+++ b/microsoft-365/commerce/subscriptions/back-up-data-before-switching-plans.md
@@ -27,6 +27,10 @@ description: "Backup Outlook, OneDrive, Yammer, and SharePoint content before ch
 # Back up data before switching Microsoft 365 for business plans
 
 If a user will be switched to another subscription that has fewer data-related services or a user leaves the organization, a copy of their data that's stored in Microsoft 365 can be downloaded before they are switched to the new subscription.
+
+ > [!NOTE]
+ > It's not required to back up data when you switch to another subscription that provides more and same services. User data will always be preserved and no action need be taken for any individual service that is present in both  expiring and replacement subscription assigned to the same user.
+
   
 ## Save a copy of Outlook information
 


### PR DESCRIPTION
Added a note to the document stating that "It's not required to back up data when you switch to another subscription that provides more and same services. User data will always be preserved and no action need be taken for any individual service that is present in both  expiring and replacement subscription assigned to the same user" as currently the users were under the assumption that it works but it needed clarity.