### PR TITLE
Correction on who can receive email notifications

### DIFF
--- a/microsoft-365/compliance/disposition.md
+++ b/microsoft-365/compliance/disposition.md
@@ -57,7 +57,7 @@ When content reaches the end of its retention period, there are several reasons 
 
 When a disposition review is triggered at the end of the retention period:
   
-- The people you choose receive an email notification that they have content to review. These reviewers can be individual users, distribution or security groups, or Microsoft 365 groups ([formerly Office 365 groups](https://techcommunity.microsoft.com/t5/microsoft-365-blog/office-365-groups-will-become-microsoft-365-groups/ba-p/1303601)). Note that notifications are sent on a weekly basis.
+- The people you choose receive an email notification that they have content to review. These reviewers can be individual users or mail-enabled security groups. Note that notifications are sent on a weekly basis.
     
 - The reviewers go to the **Disposition** tab in the Microsoft 365 compliance center to review the content and decide whether to permanently delete it, extend its retention period, or apply a different retention label.
 


### PR DESCRIPTION
Corrected a contradiction in the article. On line 60 it previously stated that "reviewers can be individual users, distribution or security groups, or Microsoft 365 groups". But further down the same page on line 89, there is a note saying that you can only specify users or mail-enabled security groups, and that Microsoft 365 groups are not supported. Through my own testing I found that the note is correct, e.g. you can only specify users or mail-enabled security groups. I changed line 60 in the article to remove the incorrect information (e.g. removed "Microsoft 365 groups" and changed "distribution or security groups" to say "mail-enabled security groups").