### PR TITLE
Add missing closing > to codeblock

### DIFF
--- a/microsoft-365/security/office-365-security/configure-the-outbound-spam-policy.md
+++ b/microsoft-365/security/office-365-security/configure-the-outbound-spam-policy.md
@@ -356,7 +356,7 @@ For detailed syntax and parameter information, see [Get-HostedOutboundSpamFilter
 To view existing outbound spam filter rules, use the following syntax:
 
 ```PowerShell
-Get-HostedOutboundSpamFilterRule [-Identity "<RuleIdentity>"] [-State <Enabled | Disabled]
+Get-HostedOutboundSpamFilterRule [-Identity "<RuleIdentity>"] [-State <Enabled | Disabled>]
 ```
 
 To return a summary list of all outbound spam filter rules, run this command:


### PR DESCRIPTION
Add missing > to first codeblock under this heading: "Use PowerShell to view outbound spam filter rules".

Didn't notice this when fixing #2813 