### PR TITLE
Update add-domain.md

### DIFF
--- a/microsoft-365/admin/setup/add-domain.md
+++ b/microsoft-365/admin/setup/add-domain.md
@@ -131,7 +131,7 @@ In the wizard, we'll just confirm that you own the domain, and then automaticall
 - [EuroDNS](https://www.eurodns.com/)
 - [Cloudflare](https://www.cloudflare.com/)
 - [GoDaddy](https://www.godaddy.com/)
-- [WordPress](https://wordpress.com/)
+- [WordPress.com](https://wordpress.com/)
 - [Plesk](https://www.plesk.com/)
 - [MediaTemple](https://mediatemple.net/)
 - SecureServer or WildWestDomains (GoDaddy resellers using SecureServer DNS hosting)


### PR DESCRIPTION
Corrected wordpress to wordpress.com as WordPress' refers to the open-source WordPress project, not WordPress.com. When referring to "WordPress" as a domain registrar, the correct name should be "WordPress.com".