### PR TITLE
Update classifier-get-started-with.md

### DIFF
--- a/microsoft-365/compliance/classifier-get-started-with.md
+++ b/microsoft-365/compliance/classifier-get-started-with.md
@@ -73,7 +73,7 @@ When you want a trainable classifier to independently and accurately identify an
 
 ### Testing content
 
-Once the trainable classifier has processed enough positive samples to build a prediction model, you need to test the predictions it makes to see if the classifier can correctly distinguish between items that match the category and items that don't. You do this by feeding it another, hopefully larger, set of human picked content that consists of samples that should fall into the category and samples that won't. Once it processes those, you manually go through the results and verify whether each prediction is correct, incorrect, or you aren't sure. The trainable classifier uses this feedback to improve its prediction model.
+Once the trainable classifier has processed enough positive samples to build a prediction model, you need to test the predictions it makes to see if the classifier can correctly distinguish between items that match the category and items that don't. You do this by selecting another, hopefully larger, set of human picked content that consists of samples that should fall into the category and samples that won't. You should test with different data than the initial seed data you first provided. Once it processes those, you manually go through the results and verify whether each prediction is correct, incorrect, or you aren't sure. The trainable classifier uses this feedback to improve its prediction model.
 
 > [!TIP]
 > For best results, have at least 200 items in your test sample set with an even distribution of positive and negative matches.


### PR DESCRIPTION
I've noticed that a few customers are using the seed data as part of the test data. It's best to have a separate set of positives rather than re-use the seed data, so I wanted to clarify this in our support docs.