### PR TITLE
Update to import data into Advanced eDiscovery

### DIFF
--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -63,7 +63,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
 8. The first tab is **1. Prepare step**. Select **Next: Upload files**.
 
-9. On the **2. Upload files** tab you will be promoted to download AzCopy.exe if you have not and then provide the path to the file location.  For example, `C:\Upload`.  This will give you the command to execute for AzCopy.exe, for example using `C:\Upload` you would see:
+9. On the **2. Upload files** tab you will be prompted to download AzCopy.exe if you have not done so already, and then to provide the path to the file location. For example, `C:\Upload`  will give you the command to execute AzCopy.exe. Using `C:\Upload`, you will see:
 
   `"%ProgramFiles(x86)%\Microsoft SDKs\Azure\AzCopy\AzCopy.exe" /Source:"c:\upload" /Dest:"https://spnam03salinkexternal003.blob.core.windows.net/16d13440-a6a4-4bc5-a82b-10ac9cfe9d7c-1601401811-externalstore?sv=2017-07-29&sr=c&si=ExternalStore63%7C0&sig=9Dq5v20TwkxByYDHhIEx%2FHSLlmlqUjY0njkJyTO0zGA%3D" /s`
   

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -69,7 +69,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
   
 10. Open a command prompt window and execute the AzCopy.exe command to import the data into Azure. Once it has loaded all of the data, select **Next: Process files**.
 
-11. The next tab is **3. Process files** where you will see the custodians that had data associated with them and will show you the progress of the data being imported.
+11. The next tab is **3. Process files** where you will see the custodians that have data associated with them and will also show you the progress of the data being imported.
         
     For more information on Azcopy syntax see, [Transfer data with the AzCopy on Windows](https://docs.microsoft.com/azure/storage/common/storage-use-azcopy) . 
     

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -57,7 +57,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
 5. Select **Manage review set**.
 
-6. In the Non-Office 365 data card, click on **View Uploads**
+6. In the Non-Office 365 data card, select **View Uploads**.
 
 7. Click on **Upload files** to start the file upload wizard
 

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -73,7 +73,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
         
     For more information on Azcopy syntax see, [Transfer data with the AzCopy on Windows](https://docs.microsoft.com/azure/storage/common/storage-use-azcopy) . 
     
-    For more details on Advanced eDiscovery Processing see, [Run the Process module and load data in Advanced eDiscovery](run-the-process-module-and-load-data-in-advanced-ediscovery.md) 
+    For more details on Advanced eDiscovery Processing, see [Run the Process module and load data in Advanced eDiscovery (classic)](run-the-process-module-and-load-data-in-advanced-ediscovery.md). 
     
     > [!IMPORTANT]
     > There must be one root folder per user and the folder name must be in the  *alias@domainname*  format. 

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -59,7 +59,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
 6. In the Non-Office 365 data card, select **View Uploads**.
 
-7. Click on **Upload files** to start the file upload wizard
+7. Choose **Upload files** to start the file upload wizard.
 
 8. The first tab is the **1. Prepare step**. Click on **Next: Upload files**
 

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -55,7 +55,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
 4. Select an existing Review Set or choose **Add Review Set**.
 
-5. Select **Manage review set**
+5. Select **Manage review set**.
 
 6. In the Non-Office 365 data card, click on **View Uploads**
 

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -51,7 +51,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
     
 2. Click **Switch to Advanced eDiscovery**
 
-3. Select **Review Sets** from the menu
+3. Select **Review Sets** from the menu.
 
 4. Select and existing Review Set or click on **Add Review Set**
 

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -50,36 +50,34 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 1. As an eDiscovery Manager or eDiscovery Administrator, open **eDiscovery**, and open the case that the non-Office 365 data will be uploaded to. If you need to create a case, see [Manage eDiscovery cases in the Security &amp; Compliance Center](ediscovery-cases.md)
     
 2. Click **Switch to Advanced eDiscovery**
-    
-3. Under **Source type** select **Non-Office 365 data**.
-    
-4. Click **Add container**. Name the container and add a description.
-    
-5. Select the newly added container from the container list and copy the URL that appears in the container details pane and then close the pane
-    
-6. Open a command prompt as an administrator and change directory to folder where you have AzCopy installed..
-    
-7. Construct the AzCopy command line to upload the files like this:
-    
-    AzCopy /Source:" *full path to root folder on local machine*  " /Dest:"  *container URL up to but not including the ?*  " /DestSAS:"  *remainder of the container url from the ? to the end*  " /S. 
-    
-    For example, using these values: 
-    
-  - root folder - C:\Collected Data 
-    
-  - container url - https://zoomsabcprodeuss114.blob.core.windows.net/ingestion53d059efe5f74784afb308f66cdebf17?sv=2015-04-05&amp;sr=c&amp;si=NonOfficeData15%7C0&amp;sig=Bk5INP8CUfv1y4CSJiJl3pJt3Ekvu8GS3P8NkOvoQxA%3D
-    
-    the AzCopy command line syntax would be:
-    
-     `AzCopy /Source:"C:\CollectedData" /Dest:"https://zoomsabcprodeuss114.blob.core.windows.net/ingestion53d059efe5f74784afb308f66cdebf17" /DestSAS:"?sv=2015-04-05&amp;sr=c&amp;si=NonOfficeData15%7C0&amp;sig=Bk5INP8CUfv1y4CSJiJl3pJt3Ekvu8GS3P8NkOvoQxA%3D" /S`
-    
+
+3. Select **Review Sets** from the menu
+
+4. Select and existing Review Set or click on **Add Review Set**
+
+5. Select **Manage review set**
+
+6. In the Non-Office 365 data card, click on **View Uploads**
+
+7. Click on **Upload files** to start the file upload wizard
+
+8. The first tab is the **1. Prepare step**. Click on **Next: Upload files**
+
+9. On the **2. Upload files** tab you will be promoted to download AzCopy.exe if you have not and then provide the path to the file location.  For example, `C:\Upload`.  This will give you the command to execute for AzCopy.exe, for example using `C:\Upload` you would see:
+
+  `"%ProgramFiles(x86)%\Microsoft SDKs\Azure\AzCopy\AzCopy.exe" /Source:"c:\upload" /Dest:"https://spnam03salinkexternal003.blob.core.windows.net/16d13440-a6a4-4bc5-a82b-10ac9cfe9d7c-1601401811-externalstore?sv=2017-07-29&sr=c&si=ExternalStore63%7C0&sig=9Dq5v20TwkxByYDHhIEx%2FHSLlmlqUjY0njkJyTO0zGA%3D" /s`
+  
+10. Open a command prompt window and execute the AzCopy.exe command to import the data into Azure.  Once it has loaded all of the data then click on **Next: Process files**
+
+11. The next tab is **3. Process files** where you will see the custodians that had data associated with them and will show you the progress of the data being imported.
+        
     For more information on Azcopy syntax see, [Transfer data with the AzCopy on Windows](https://docs.microsoft.com/azure/storage/common/storage-use-azcopy) . 
+    
+    For more details on Advanced eDiscovery Processing see, [Run the Process module and load data in Advanced eDiscovery](run-the-process-module-and-load-data-in-advanced-ediscovery.md) 
     
     > [!IMPORTANT]
     > There must be one root folder per user and the folder name must be in the  *alias@domainname*  format. 
-  
-8. Once the folders have finished uploading, switch back to Advanced eDiscovery. The content in the folders you uploaded is now ready to be processed in Advanced eDiscovery. Select the container and click the Process button. For more details on Advanced eDiscovery Processing see, [Run the Process module and load data in Advanced eDiscovery](run-the-process-module-and-load-data-in-advanced-ediscovery.md)
-    
+   
     > [!IMPORTANT]
     > Once the container is successfully processed in Advanced eDiscovery, you will no longer be able to add new content to the SAS storage in Azure. If you collect additional content and you want to add it to the case for Advanced eDiscovery analysis, you must create a new **Non-Office 365 data** container and repeat this procedure. 
   

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -61,7 +61,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
 7. Choose **Upload files** to start the file upload wizard.
 
-8. The first tab is the **1. Prepare step**. Click on **Next: Upload files**
+8. The first tab is **1. Prepare step**. Select **Next: Upload files**.
 
 9. On the **2. Upload files** tab you will be promoted to download AzCopy.exe if you have not and then provide the path to the file location.  For example, `C:\Upload`.  This will give you the command to execute for AzCopy.exe, for example using `C:\Upload` you would see:
 

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -67,7 +67,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
   `"%ProgramFiles(x86)%\Microsoft SDKs\Azure\AzCopy\AzCopy.exe" /Source:"c:\upload" /Dest:"https://spnam03salinkexternal003.blob.core.windows.net/16d13440-a6a4-4bc5-a82b-10ac9cfe9d7c-1601401811-externalstore?sv=2017-07-29&sr=c&si=ExternalStore63%7C0&sig=9Dq5v20TwkxByYDHhIEx%2FHSLlmlqUjY0njkJyTO0zGA%3D" /s`
   
-10. Open a command prompt window and execute the AzCopy.exe command to import the data into Azure.  Once it has loaded all of the data then click on **Next: Process files**
+10. Open a command prompt window and execute the AzCopy.exe command to import the data into Azure. Once it has loaded all of the data, select **Next: Process files**.
 
 11. The next tab is **3. Process files** where you will see the custodians that had data associated with them and will show you the progress of the data being imported.
         

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -53,7 +53,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
 3. Select **Review Sets** from the menu.
 
-4. Select and existing Review Set or click on **Add Review Set**
+4. Select an existing Review Set or choose **Add Review Set**.
 
 5. Select **Manage review set**
 

--- a/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
+++ b/microsoft-365/compliance/import-non-office-365-data-into-advanced-ediscovery.md
@@ -71,7 +71,7 @@ Using the upload Non-Office 365 feature as described in this procedure requires 
 
 11. The next tab is **3. Process files** where you will see the custodians that have data associated with them and will also show you the progress of the data being imported.
         
-    For more information on Azcopy syntax see, [Transfer data with the AzCopy on Windows](https://docs.microsoft.com/azure/storage/common/storage-use-azcopy) . 
+    For more information on Azcopy syntax, see [Transfer data with the AzCopy on Windows](https://docs.microsoft.com/azure/storage/common/storage-use-azcopy). 
     
     For more details on Advanced eDiscovery Processing, see [Run the Process module and load data in Advanced eDiscovery (classic)](run-the-process-module-and-load-data-in-advanced-ediscovery.md). 
     


### PR DESCRIPTION
The steps to import non-O365 data into an Advanced eDiscovery case are no longer correct with the new UI.  I have updated those steps to use the new method of adding a Review Set to the Case and then uploading files into the Review Set and processing them.