### PR TITLE
Clarify the constraint about pre-existing files not being scanned

### DIFF
--- a/microsoft-365/compliance/apply-sensitivity-label-automatically.md
+++ b/microsoft-365/compliance/apply-sensitivity-label-automatically.md
@@ -197,7 +197,7 @@ Make sure you're aware of the prerequisites before you configure auto-labeling p
     - At the time the auto-labeling policy runs, the file mustn't be open by another process or user. A file that's checked out for editing falls into this category.
 
 - If you plan to use [custom sensitive information types](custom-sensitive-info-types.md) rather than the built-in sensitivity types: 
-    - Custom sensitivity information types are evaluated for content that is created after the custom sensitivity information types are saved. 
+    - Custom sensitivity information types are evaluated for content that is added to SharePoint or OneDrive after the custom sensitivity information types are saved. 
     - To test new custom sensitive information types, create them before you create your auto-labeling policy, and then create new documents with sample data for testing.
 
 - One or more sensitivity labels [created and published](create-sensitivity-labels.md) (to at least one user) that you can select for your auto-labeling policies. For these labels:


### PR DESCRIPTION
Large customer was interpreting "files must be created after..." as it not being able to scan old files that were uploaded to SharePoint after the creation of the SIT. I have clarified that the constraint is that the files must not be present in SP/OD before the creation of the SIT, not them being written before the creation of the SIT.