### PR TITLE
Update dlp-sensitivity-label-as-condition.md

### DIFF
--- a/microsoft-365/compliance/dlp-sensitivity-label-as-condition.md
+++ b/microsoft-365/compliance/dlp-sensitivity-label-as-condition.md
@@ -35,6 +35,10 @@ Sensitivity labels appear as an option in the **Content contains** list.
 
 ![sensitivity label as a condition](../media/dlp-sensitivity-label-as-a-condition.png)
 
+> [!IMPORTANT]
+> “Sensitivity Labels” as a condition will not be available if you have selected “Teams chat and channel messages” as a location to apply the DLP policy.
+
+
 ## Supported items, scenarios, and policy tips
 
 You can use sensitivity labels as conditions on these items and in these scenarios.


### PR DESCRIPTION
> [!IMPORTANT]
> “Sensitivity Labels” as a condition will not be available if you have selected “Teams chat and channel messages” as a location to apply the DLP policy.