### PR TITLE
Update centralized-deployment-of-add-ins.md

### DIFF
--- a/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
+++ b/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
@@ -130,7 +130,7 @@ When the tool finishes running, it produces an output file in comma-separated (.
 - Supported Mailbox - If they are on an OAuth-enabled mailbox
 
 > [!NOTE]
-> MFA is not supported when using the Central Deployment for Addins Powershell module.
+> Multifactor authentication is not supported when using the Central Deployment for add-ins PowerShell module.
   
 ## User and group assignments
 
@@ -167,4 +167,3 @@ If you or your users encounter problems loading the add-in while using Office ap
 |Office  <br/> | Charles/Fiddler logs  <br/>  Tenant ID ( [learn how](https://docs.microsoft.com/onedrive/find-your-office-365-tenant-id.aspx))  <br/>  CorrelationID. View the source of one of the office pages and look for the Correlation ID value and send it to support:  <br/>`<input name=" **wdCorrelationId**" type="hidden" value=" **{BC17079E-505F-3000-C177-26A8E27EB623}**">`  <br/>  `<input name="user_id" type="hidden" value="1003bffd96933623"></form>`  <br/> |
 |Rich clients (Windows, Mac)  <br/> | Charles/Fiddler logs  <br/>  Build numbers of the client app (preferably as a screenshot from **File/Account**)  <br/> |
    
-

--- a/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
+++ b/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
@@ -129,7 +129,8 @@ When the tool finishes running, it produces an output file in comma-separated (.
     
 - Supported Mailbox - If they are on an OAuth-enabled mailbox
 
-
+> [!NOTE]
+> MFA is not supported when using the Central Deployment for Addins Powershell module.
   
 ## User and group assignments
 

--- a/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
+++ b/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
@@ -130,7 +130,7 @@ When the tool finishes running, it produces an output file in comma-separated (.
 - Supported Mailbox - If they are on an OAuth-enabled mailbox
 
 > [!NOTE]
-> Multifactor authentication is not supported when using the Central Deployment for add-ins PowerShell module.
+> Multifactor authentication is not supported when using the Central Deployment PowerShell module.
   
 ## User and group assignments
 


### PR DESCRIPTION
added a note that MFA is not supported when using the Central Deployment for Addins Powershell module.