### PR TITLE
Update readiness-assessment-fix.md

### DIFF
--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -134,9 +134,9 @@ Make sure that any profiles that have the **Show app and profile configuration p
 
 Windows 10 devices in your Azure AD organization must be automatically enrolled in Intune.
 
-**Not ready**
+**Advisory**
 
-Users in your Azure AD organization aren't automatically enrolled in Microsoft Intune. Change the MDM User scope to **Some** or **All**. If you choose **Some**, come back after enrollment and select the **Modern Workplace -All** Azure AD group for **Groups**.
+Make sure the MDM User scope is set to **Some** or **All**; it cannot be set to **None**.  If you choose **Some**, come back after enrollment and select the **Modern Workplace -All** Azure AD group for **Groups**.
 
 
 ### Microsoft Store for Business

--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -136,7 +136,7 @@ Windows 10 devices in your Azure AD organization must be automatically enrolled 
 
 **Advisory**
 
-Make sure the MDM User scope is set to **Some** or **All**; it cannot be set to **None**.  If you choose **Some**, come back after enrollment and select the **Modern Workplace -All** Azure AD group for **Groups**.
+Make sure the MDM User scope is set to **Some** or **All**, not **None**. If you choose **Some**, come back after enrollment and select the **Modern Workplace -All** Azure AD group for **Groups**.
 
 
 ### Microsoft Store for Business


### PR DESCRIPTION
Changed Not ready status for Intune enrollment to Advisory as dev team discovered API is unable to accurately detect failed settings.  Best is to flag this setting for everyone to manually check until required API is found and added to code.