### PR TITLE
Update readiness-assessment-fix.md

### DIFF
--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -124,11 +124,11 @@ You currently have the Enrollment Status Page (ESP) enabled. If you are particip
 
 **Not ready**
 
-You have the ESP default profile set to **Show app and profile configuration progress**. Disable this setting by following the steps in [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/windows-enrollment-status).
+You have the ESP default profile set to **Show app and profile configuration progress**.  Disable this setting or make sure that assignments to any Azure AD group do not include Microsoft Managed Desktop devices by following the steps in [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/windows-enrollment-status).
 
 **Advisory**
 
-Make sure that any profiles that have the **Show app and profile configuration progress** setting are not assigned to any Azure AD group that includes Microsoft Managed Desktop devices. For more information, see [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/windows-enrollment-status).
+Make sure that any profiles that have the **Show app and profile configuration progress** setting are not assigned to any Azure AD group that includes Microsoft Managed Desktop devices. For more information, see [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/winows-enrollment-status).
 
 ### Intune enrollment
 

--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -124,7 +124,7 @@ You currently have the Enrollment Status Page (ESP) enabled. If you are particip
 
 **Not ready**
 
-You have the ESP default profile set to **Show app and profile configuration progress**.  Disable this setting or make sure that assignments to any Azure AD group do not include Microsoft Managed Desktop devices by following the steps in [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/windows-enrollment-status).
+You have the ESP default profile set to **Show app and profile configuration progress**. Disable this setting or make sure that assignments to any Azure AD group do not include Microsoft Managed Desktop devices by following the steps in [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/windows-enrollment-status).
 
 **Advisory**
 

--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -128,7 +128,7 @@ You have the ESP default profile set to **Show app and profile configuration pro
 
 **Advisory**
 
-Make sure that any profiles that have the **Show app and profile configuration progress** setting are not assigned to any Azure AD group that includes Microsoft Managed Desktop devices. For more information, see [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/winows-enrollment-status).
+Make sure that any profiles that have the **Show app and profile configuration progress** setting are not assigned to any Azure AD group that includes Microsoft Managed Desktop devices. For more information, see [Set up the Enrollment Status Page](https://docs.microsoft.com/mem/intune/enrollment/windows-enrollment-status).
 
 ### Intune enrollment
 


### PR DESCRIPTION
Updated Advisory guidance for ESP to reflect that the default policy, if enabled, should not be assigned to all devices but should be assigned instead to specific Azure AD groups