### PR TITLE
Update readiness-assessment-fix.md

### DIFF
--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -240,7 +240,7 @@ You have an "update ring" policy that targets all devices, all users, or both. C
 
 **Advisory**
 
-Make sure that any update ring policies you have exclude the **Modern Workplace -All** Azure AD group. For steps, see [Manage Windows 10 software updates in Intune](https://docs.microsoft.com/mem/intune/protect/windows-update-for-business-configure). The **Modern Workplace Devices -All** Azure AD group is a dynamic group that we create when you enroll in Microsoft Managed Desktop, so you'll have to come back to exclude this group after enrollment.
+Make sure that any update ring policies you have exclude the **Modern Workplace Devices -All** Azure AD group. If you have assigned Azure AD user group to these policies, make sure that any update ring policies you have also excluded the **Modern Workplace -All** Azure AD group which includes your Microsoft Managed Desktop users. For steps, see [Manage Windows 10 software updates in Intune](https://docs.microsoft.com/mem/intune/protect/windows-update-for-business-configure). Both the **Modern Workplace Devices -All** and **Modern Workplace -All** Azure AD groups are assigned groups that we create when you enroll in Microsoft Managed Desktop, so you'll have to come back to exclude this group after enrollment.
 
 
 ## Azure Active Directory settings


### PR DESCRIPTION
Updates to the Windows update rings policy to specify there are two AAD groups-- one for Devices and one for users.  This wasn't clear previously.

@jaimeo , this is an edit for the Windows update ring policy.  Thank you! 