### PR TITLE
Removing M365 E5 IP+DLP

### DIFF
--- a/microsoft-365/compliance/endpoint-dlp-getting-started.md
+++ b/microsoft-365/compliance/endpoint-dlp-getting-started.md
@@ -39,7 +39,7 @@ Before you get started with Endpoint DLP, you should confirm your [Microsoft 365
 - Microsoft 365 A5 compliance
 - Microsoft 365 E5 information protection and governance
 - Microsoft 365 A5 information protection and governance
-- Microsoft 365 E5 information protection and data loss prevention (only available with the E5 security, Enterprise Mobility and Security E5, Microsoft Cloud App Security, and Microsoft Defender Advanced Threat Protection)
+
 
 ### Permissions
 


### PR DESCRIPTION
Removing M365 E5 IP+DLP as this is not a customer facing license, only for internal sale purpose. Confirmed with Eric Ouellet.
@chrfox