### PR TITLE
Added considerations for surrounding strings with quotes if they have commas

### DIFF
--- a/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
+++ b/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
@@ -102,7 +102,7 @@ Setting up and configuring EDM-based classification involves:
 
 #### Define the schema for your database of sensitive information
 
-3. Define the schema for the database of sensitive information in XML format (similar to our example below). Name this schema file **edm.xml**, and configure it such that for each column in the database, there is a line that uses the syntax: 
+1. Define the schema for the database of sensitive information in XML format (similar to our example below). Name this schema file **edm.xml**, and configure it such that for each column in the database, there is a line that uses the syntax: 
 
       `\<Field name="" searchable=""/\>`.
 
@@ -636,4 +636,3 @@ EDM sensitive information types for following scenarios are currently in develop
 - [Overview of DLP policies](data-loss-prevention-policies.md)
 - [Microsoft Cloud App Security](https://docs.microsoft.com/cloud-app-security)
 - [New-DlpEdmSchema](https://docs.microsoft.com/powershell/module/exchange/new-dlpedmschema)
-

--- a/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
+++ b/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
@@ -98,6 +98,8 @@ Setting up and configuring EDM-based classification involves:
 
 2. Structure the sensitive data in the .csv file such that the first row includes the names of the fields used for EDM-based classification. In your .csv file, you might have field names, such as "ssn", "birthdate", "firstname", "lastname". The column header names can't include spaces or underscores. For example, the sample .csv file that we use in this article is named *PatientRecords.csv*, and its columns include *PatientID*, *MRN*, *LastName*, *FirstName*, *SSN*, and more.
 
+3. Pay attention to the format of the sensitive data fields. In particular, fields that may contain commas in their content (e.g. a street address that contains the value "Seattle,WA") would be parsed as two eparate fields when parsed by the EDM tool. In order to avoid this, you need to ensure such fields are surrounded by single or double quotes in the sensitive data table. If fields with commas in them may also contain spaces, you would need to create a custom Sensitive Information Type that matches the corresponding format (e.g. a multi-word string with commas and spaces in it) to ensure the string is correctly matched wjen the document is scanned.
+
 #### Define the schema for your database of sensitive information
 
 3. Define the schema for the database of sensitive information in XML format (similar to our example below). Name this schema file **edm.xml**, and configure it such that for each column in the database, there is a line that uses the syntax: 


### PR DESCRIPTION
… commas as per dev team's input

As per dev team's input:
CSV Field Value	Classification Text	Would Match?
Seattle,WA	Seattle,WA	Yes
	Seattle,<space>WA 	Yes but custom SIT would be required.
		
Seattle,<space>WA	Seattle,<space>WA	Yes but custom SIT would be required.
	Seattle,<space>WA	Yes but custom SIT would be required.

Custom SIT is required because “<space>” causes EDM to treat “Seattle” and “WA” as two different words and it won’t match them as single entity. Tenant can create a custom SIT (regEx to include space match) as a workaround. This workaround may not be acceptable to some of the tenants. We are working with Martin to prioritize change in next milestone so that custom SIT won’t be required for “Seattle,<space>WA” case.