### PR TITLE
Update view-licensed-and-unlicensed-users-with-microsoft-365-powershe…

### DIFF
--- a/microsoft-365/enterprise/view-licensed-and-unlicensed-users-with-microsoft-365-powershell.md
+++ b/microsoft-365/enterprise/view-licensed-and-unlicensed-users-with-microsoft-365-powershell.md
@@ -41,7 +41,7 @@ Get-AzureAdUser | ForEach{ $licensed=$False ; For ($i=0; $i -le ($_.AssignedLice
 To view the list of all user accounts in your organization that have been assigned any of your licensing plans (licensed users), run the following command:
   
 ```powershell
-Get-AzureAdUser | ForEach { $licensed=$True ; For ($i=0; $i -le ($_.AssignedLicenses | Measure).Count ; $i++) { If( [string]::IsNullOrEmpty(  $_.AssignedLicenses[$i].SkuId ) -ne $True) { $licensed=$true } } ; If( $licensed -eq $true) { Write-Host $_.UserPrincipalName} }
+Get-AzureAdUser | ForEach { $licensed=$False ; For ($i=0; $i -le ($_.AssignedLicenses | Measure).Count ; $i++) { If( [string]::IsNullOrEmpty(  $_.AssignedLicenses[$i].SkuId ) -ne $True) { $licensed=$true } } ; If( $licensed -eq $true) { Write-Host $_.UserPrincipalName} }
 ```
 
 >[!Note]


### PR DESCRIPTION
…ll.md

I think that in the example code for getting licensed users, it should be `$licensed = $False` in the declaration instead of `$licensed = $True`. Otherwise there is never an exception case.

Currently the list returns users with or without assigned licenses. In the submitted PR, it returns a list only of users with assigned licenses.