### PR TITLE
Update investigating-partially-indexed-items-in-ediscovery.md

### DIFF
--- a/microsoft-365/compliance/investigating-partially-indexed-items-in-ediscovery.md
+++ b/microsoft-365/compliance/investigating-partially-indexed-items-in-ediscovery.md
@@ -40,7 +40,7 @@ After you run an eDiscovery search, the total number and size of partially index
   
 - If an item is partially indexed and matches the search query, it's included in both the count (and size) of search result items and partially indexed items. However, when the results of that same search are exported, the item is included only with set of search results; it's not included as a partially indexed item.
 
-- If you specify a date range for a search query (by including it in the keyword query or by using a condition), any partially indexed item that doesn't match the date range isn't included in the count of partially indexed items. Only the partially indexed items that fall within date range are included in the count of partially indexed items.
+- If you specify a date range for a search query (by including it in the keyword query or by using a condition), any partially indexed item that doesn't match the date range isn't included in the count of partially indexed items. Only the partially indexed items that fall within date range are included in the count of indexed items.
 
 > [!NOTE]
 > Partially indexed items located in SharePoint and OneDrive sites *are not* included in the estimate of partially indexed items that's displayed in the detailed statistics for the search. However, partially indexed items can be exported when you export the results of an eDiscovery search. For example, if you only search sites, the estimated number partially indexed items will be zero.


### PR DESCRIPTION
if a partially indexed item has metadata (metadata is indexed by definition) that matched the search condition(date range) then it will be returned with the regular Indexed items.

See https://docs.microsoft.com/en-us/microsoft-365/compliance/partially-indexed-items-in-content-search?view=o365-worldwide#messages-and-documents-with-partially-indexed-file-types-can-be-returned-in-search-results  👍 
"Similarly, messages with partially indexed file attachments and documents of a partially indexed file type are included in search results when other message or document properties, which are indexed and searchable, meet the search criteria. Message properties that are indexed for search include sent and received dates, sender and recipient, the file name of an attachment, and text in the message body. Document properties indexed for search include created and modified dates. So even though a message attachment may be a partially indexed item, the message will be included in the regular search results if the value of other message or document properties matches the search criteria."