### PR TITLE
Updated the rule package syntax to avoid too broad Classification element

### DIFF
--- a/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
+++ b/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
@@ -204,7 +204,7 @@ In this example, where both `caseInsensitive` and `ignoredDelimiters` are used, 
 
       - **idMatch**: This field points to the primary element for EDM.
         - Matches: Specifies the field to be used in exact lookup. You provide a searchable field name in EDM Schema for the DataStore.
-        - Classification: This field specifies the sensitive type match that triggers EDM lookup. You can provide Name or GUID of an existing built-in or custom sensitive information type. Be aware that any string that matches the sensitive info type provided will be hashed and compared to every entry in the sensitive information table. In order to avoid causing performance issues, if you use a custom sensitive information type as the Classification element in EDM avoid using one that will match a large percentage of content (e.g. "any number" or "any five letter word") by adding supporting keywords or including formatting in the definiton of the custom classification sensitive information type. 
+        - Classification: This field specifies the sensitive type match that triggers EDM lookup. You can provide the Name or GUID of an existing built-in or custom sensitive information type. Be aware that any string that matches the sensitive information type provided will be hashed and compared to every entry in the sensitive information table. In order to avoid causing performance issues, if you use a custom sensitive information type as the Classification element in EDM, avoid using one that will match a large percentage of content (such as "any number" or "any five-letter word") by adding supporting keywords or including formatting in the definition of the custom classification sensitive information type. 
 
       - **Match:** This field points to additional evidence found in proximity of idMatch.
         - Matches: You provide any field name in EDM Schema for DataStore.
@@ -648,4 +648,3 @@ EDM sensitive information types for following scenarios are currently in develop
 - [Microsoft Cloud App Security](https://docs.microsoft.com/cloud-app-security)
 - [New-DlpEdmSchema](https://docs.microsoft.com/powershell/module/exchange/new-dlpedmschema)
 - [Modify Exact Data Match schema to use configurable match](sit-modify-edm-schema-configurable-match.md)
-

--- a/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
+++ b/microsoft-365/compliance/create-custom-sensitive-information-types-with-exact-data-match-based-classification.md
@@ -204,7 +204,7 @@ In this example, where both `caseInsensitive` and `ignoredDelimiters` are used, 
 
       - **idMatch**: This field points to the primary element for EDM.
         - Matches: Specifies the field to be used in exact lookup. You provide a searchable field name in EDM Schema for the DataStore.
-        - Classification: This field specifies the sensitive type match that triggers EDM lookup. You can provide Name or GUID of an existing built-in or custom classification.
+        - Classification: This field specifies the sensitive type match that triggers EDM lookup. You can provide Name or GUID of an existing built-in or custom sensitive information type. Be aware that any string that matches the sensitive info type provided will be hashed and compared to every entry in the sensitive information table. In order to avoid causing performance issues, if you use a custom sensitive information type as the Classification element in EDM avoid using one that will match a large percentage of content (e.g. "any number" or "any five letter word") by adding supporting keywords or including formatting in the definiton of the custom classification sensitive information type. 
 
       - **Match:** This field points to additional evidence found in proximity of idMatch.
         - Matches: You provide any field name in EDM Schema for DataStore.


### PR DESCRIPTION
…ments

Customers are hitting throttling limits by using a base SIT for the classification element in their EDM SIT that is too broad (e.g. "any number"). Added a clarification to the explanation of the Classification element to avoid customers hitting this issue.