### PR TITLE
Add missing word in external-email-forwarding.md

### DIFF
--- a/microsoft-365/security/office-365-security/external-email-forwarding.md
+++ b/microsoft-365/security/office-365-security/external-email-forwarding.md
@@ -20,7 +20,7 @@ description: "."
 
 [!INCLUDE [Microsoft 365 Defender rebranding](../includes/microsoft-defender-for-office.md)]
 
-As an admin, you might have company requirements to restrict or control automatically forwarded messages to external recipients (recipients outside of your organization). Email forwarding can be a useful, but can also pose a security risk due to the potential disclosure of information. Attackers might use this information to attack your organization or partners.
+As an admin, you might have company requirements to restrict or control automatically forwarded messages to external recipients (recipients outside of your organization). Email forwarding can be a useful feature, but can also pose a security risk due to the potential disclosure of information. Attackers might use this information to attack your organization or partners.
 
 The following types of automatic forwarding are available in Microsoft 365:
 


### PR DESCRIPTION
The introductory paragraph is missing a word, rendering the sentence grammatically incomplete. This pull request supplies a reasonable replacement for the missing word. Feel free to change or expand it as appropriate.