### PR TITLE
Update usage-analytics-data-model.md

### DIFF
--- a/microsoft-365/admin/usage-analytics/usage-analytics-data-model.md
+++ b/microsoft-365/admin/usage-analytics/usage-analytics-data-model.md
@@ -27,7 +27,7 @@ description: "Learn how usage analytics connects to an API and provides monthly 
 
 ## Data for the Microsoft 365 usage analytics tables
 
-Microsoft 365 usage analytics connects to an API that exposes a multidimensional data model. The APIs are in preview and can be accessed at `https://reports.office.com/pbi/v1.0/\<tenantid\>` (replace the \<tenant id\> with your tenant GUID). 
+Microsoft 365 usage analytics connects to an API that exposes a multidimensional data model. The APIs that Microsoft 365 usage analytics uses to generate its data are from the various, generally-available, Graph APIs. The function of the Microsoft 365 usage analytics API by itself is not generally available.
   
 > [!NOTE]
 > For more information, see [Working with Microsoft 365 usage reports in Microsoft Graph](https://go.microsoft.com/fwlink/p/?linkid=864336). 


### PR DESCRIPTION
We have seen tens of cases coming into CSS from customers wanting to implement the exact tables that they see on usage analytics through the Graph API as this document is misleading them into that. There is no actual documentation for the API: "https://reports.office.com/pbi/v1.0/\<tenantid\>" and this is a first-party API. Please amend the documentation to clearly point this out and simply state that customers wanting to get usage analytics outside of PowerBI need to build their own analytics model based on the already available (non-preview) Graph APIs.