### PR TITLE
Update remove-licenses-from-user-accounts-with-microsoft-365-powershe…

### DIFF
--- a/microsoft-365/enterprise/remove-licenses-from-user-accounts-with-microsoft-365-powershell.md
+++ b/microsoft-365/enterprise/remove-licenses-from-user-accounts-with-microsoft-365-powershell.md
@@ -57,30 +57,22 @@ To remove all of the licenses for a specific user account, specify the user sign
 
 ```powershell
 $userUPN="<user sign-in name (UPN)>"
-$licensePlanList = Get-AzureADSubscribedSku
-$userList = Get-AzureADUser -ObjectID $userUPN | Select -ExpandProperty AssignedLicenses | Select SkuID
+$userList = Get-AzureADUser -ObjectID $userUPN
+$Skus = $userList | Select -ExpandProperty AssignedLicenses | Select SkuID
 if($userList.Count -ne 0) {
-if($userList -is [array]) {
-for ($i=0; $i -lt $userList.Count; $i++) {
-$license = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicense
-$licenses = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicenses
-$license.SkuId = $userList[$i].SkuId
-$licenses.AddLicenses = $license
-Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
-$Licenses.AddLicenses = @()
-$Licenses.RemoveLicenses =  (Get-AzureADSubscribedSku | Where-Object -Property SkuID -Value $userList[$i].SkuId -EQ).SkuID
-Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
+    if($Skus -is [array])
+    {
+        $licenses = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicenses
+        for ($i=0; $i -lt $Skus.Count; $i++) {
+            $Licenses.RemoveLicenses +=  (Get-AzureADSubscribedSku | Where-Object -Property SkuID -Value $Skus[$i].SkuId -EQ).SkuID   
+        }
+        Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
+    } else {
+        $licenses = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicenses
+        $Licenses.RemoveLicenses =  (Get-AzureADSubscribedSku | Where-Object -Property SkuID -Value $Skus.SkuId -EQ).SkuID
+        Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
+    }
 }
-} else {
-$license = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicense
-$licenses = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicenses
-$license.SkuId = $userList.SkuId
-$licenses.AddLicenses = $license
-Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
-$Licenses.AddLicenses = @()
-$Licenses.RemoveLicenses =  (Get-AzureADSubscribedSku | Where-Object -Property SkuID -Value $userList.SkuId -EQ).SkuID
-Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
-}}
 ```
 
 ## Use the Microsoft Azure Active Directory Module for Windows PowerShell


### PR DESCRIPTION
…ll.md

The updated PowerShell will remove all licenses from the user, including ones that have a dependency on another license.  
Example is if a user has a Microsoft 365 GCC G3 license and a Microsoft 365 Audio Conferencing for GCC license.  You can't remove the Microsoft 365 GCC G3 license first or it will cause the below error:

Set-AzureADUserLicense : Error occurred while executing SetUserLicenses 
Code: Request_BadRequest
Message: License assignment failed because service plan f544b08d-1645-4287-82de-8d91f37c02a1 depends on the service plan(s) 304767db-7d23-49e8-a945-4a7eb65f9f28,a31ef4a2-f787-435e-8335-e47eb0cafc94
RequestId: ae7070c4-c0d5-48f9-a729-0c82b2d5d6d1
DateTimeStamp: Thu, 07 Jan 2021 16:24:49 GMT
HttpStatusCode: BadRequest
HttpStatusDescription: Bad Request
HttpResponseStatus: Completed
At line:14 char:1
+ Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Set-AzureADUserLicense], ApiException
    + FullyQualifiedErrorId : Microsoft.Open.AzureAD16.Client.ApiException,Microsoft.Open.AzureAD16.PowerShell.SetUserLicenses