### PR TITLE
Clarifying guidance

### DIFF
--- a/microsoft-365/compliance/retention-policies-teams.md
+++ b/microsoft-365/compliance/retention-policies-teams.md
@@ -102,7 +102,7 @@ When external users are included in a meeting that your organization hosts:
 
 ## When a user leaves the organization 
 
-If a user leaves your organization and their Microsoft 365 account is deleted, their chat messages that are subject to retention are stored in an inactive mailbox. The chat messages remain subject to any retention policy that was placed on the user before their mailbox was made inactive, and the contents are available to an eDiscovery search. For more information, see [Inactive mailboxes in Exchange Online](inactive-mailboxes-in-office-365.md). 
+For cloud user (where their mailbox is in Exchange Online), if a user leaves your organization and their Microsoft 365 account is deleted, their chat messages that are subject to retention are stored in an inactive mailbox. The chat messages remain subject to any retention policy that was placed on the user before their mailbox was made inactive, and the contents are available to an eDiscovery search. For more information, see [Inactive mailboxes in Exchange Online](inactive-mailboxes-in-office-365.md). 
 
 If the user stored any files in Teams, see the [equivalent section](retention-policies-sharepoint.md#when-a-user-leaves-the-organization) for SharePoint and OneDrive.
 


### PR DESCRIPTION
Clarifying that the guidance for when a user leaves the org that has been documented assumes the user is a cloud only user (AAD & EXO)