### PR TITLE
Replaced the term "sensitive info type collection" with "Rule package…

### DIFF
--- a/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
+++ b/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
@@ -372,7 +372,7 @@ To upload your rule package, do the following steps:
    For detailed syntax and parameter information, see [New-DlpSensitiveInformationTypeRulePackage](https://docs.microsoft.com/powershell/module/exchange/new-dlpsensitiveinformationtyperulepackage).
 
    > [!NOTE]
-   > The limit for custom sensitive information type collections is 10.
+   > The maximum number of rule packages supported is 10, but each package can contain the definition of multiple sensitive information types.
 
 4. To verify that you've successfully created a new sensitive information type, do any of the following steps:
 


### PR DESCRIPTION
…" which is what's used elsewhere.

A few customers had complained this led them to think we had a maximum of 10 SITs.