### PR TITLE
Update sp-compatible-pdf-readers-for-irm.md

### DIFF
--- a/microsoft-365/compliance/sp-compatible-pdf-readers-for-irm.md
+++ b/microsoft-365/compliance/sp-compatible-pdf-readers-for-irm.md
@@ -34,6 +34,6 @@ To use PDF files in libraries that the owner has protected with IRM, the user wi
 |Windows 10  <br/> |Azure Information Protection app  <br/> Foxit Reader  <br/> NitroPDF  <br/> Edge Chromium  <br/> |[Download Azure Information Protection app](https://go.microsoft.com/fwlink/?linkid=837797) <br/> [Download Foxit Reader](https://go.microsoft.com/fwlink/?linkid=2139326) <br/> [Download NitroPDF](https://go.microsoft.com/fwlink/?linkid=2139327) <br/> [Download Edge Chromium](https://support.microsoft.com/microsoft-edge/download-the-new-microsoft-edge-based-on-chromium-0f4a3dd7-55df-60f5-739f-00010dba52cf) <br/> |
 |Android  <br/> |Azure Information Protection app  <br/> Foxit MobilePDF with RMS  <br/> |[Download Azure Information Protection app](https://go.microsoft.com/fwlink/?linkid=836827) <br/> [Purchase Foxit MobilePDF](https://play.google.com/store/apps/details?id=com.foxit.mobile.pdf.lite) <br/> |
 |Windows Phone  <br/> |N/A  <br/> |N/A  <br/> |
-|macOS  <br/> |N/A  <br/> |N/A  <br/> |
+|macOS  <br/> |Edge Chromium  <br/> |[Download Edge Chromium](https://support.microsoft.com/microsoft-edge/download-the-new-microsoft-edge-based-on-chromium-0f4a3dd7-55df-60f5-739f-00010dba52cf)  <br/> |
 |IOS  <br/> |Azure Information Protection app  <br/> Foxit MobilePDF with RMS  <br/> |[Download Azure Information Protection app](https://go.microsoft.com/fwlink/?linkid=836828) <br/> [Purchase Foxit MobilePDF](https://play.google.com/store/apps/details?id=com.foxit.mobile.pdf.lite) <br/> |
    


### PR DESCRIPTION
Edge is now available for MacOS and is able to open up IRM-protected PDF properly.