### PR TITLE
Update audit-log-retention-policies.md

### DIFF
--- a/microsoft-365/compliance/audit-log-retention-policies.md
+++ b/microsoft-365/compliance/audit-log-retention-policies.md
@@ -52,7 +52,7 @@ Advanced Audit in Microsoft 365 provides a default audit log retention policy fo
 
 2. In the left pane of the Microsoft 365 compliance center, click **Show all**, and then click **Audit**.
 
-    The **Audit** page is displayed.
+    The **Audit** page is displayed. Click the **Audit retention policies** tab.
 
     ![The Audit log search page in the compliance center](../media/AuditLogRetentionPolicy1.png)
 


### PR DESCRIPTION
We removed the "Create Audit Retention Policy" button on the main page.  So updated the verbiage in step 2 to have them click on the "Audit retention policies" tab.

Need to update the image in step 2 to remove the "Create Audit Retention Policy" button and to move the purple outline around the "Audit retention policies tab" instead.