### PR TITLE
Update readiness-assessment-tool.md

### DIFF
--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-tool.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-tool.md
@@ -23,7 +23,7 @@ For details about using the downloadable readiness assessment checker, see [Down
 
 The online tool checks settings in Microsoft Endpoint Manager (specifically, Microsoft Intune), Azure Active Directory (Azure AD), and Microsoft 365 to ensure they will work with Microsoft Managed Desktop. Microsoft Managed Desktop retains the data associated with these checks for 12 months after the last time you run a check in your Azure AD organization (tenant). After 12 months, we retain it in de-identified form. You can choose to delete the data we collect.
 
-Anyone with at least the Intune Administrator role will be able to run this tool, but two of the checks ([Conditional access policies](readiness-assessment-fix.md#conditional-access-policies) and [Multifactor authentication](readiness-assessment-fix.md#multifactor-authentication) require additional permissions.
+Anyone with at least the Global Reader or Intune Administrator role will be able to run this tool, but two of the checks ([Conditional access policies](readiness-assessment-fix.md#conditional-access-policies) and [Multifactor authentication](readiness-assessment-fix.md#multifactor-authentication) require additional permissions.
  
 The assessment tool checks these items:
 


### PR DESCRIPTION
Added that Global Reader admin role is now allowed to run ART. Previously was only Intune Admin and Global Admin. I believe that best practice is to only list the least privileged role (in this case, Global Reader) but here chose to list both Global Reader and Intune Admin as Intune Admin (which is specific to Intune) seems sufficiently different than the Global Reader role (which goes across all admin portals). Is this correct?

@jaimeo , can you please review my edit? Thank you!