### PR TITLE
Update readiness-assessment-fix.md

### DIFF
--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -283,7 +283,7 @@ Certain account names could conflict with account names created by Microsoft Man
 
 **Not ready**
 
-You have at least one account name that will conflict with ones created by Microsoft Managed Desktop. Work with your Microsoft account representative to exclude these account names as we don't list the accounts names publicly to minimiize security risk. 
+You have at least one account name that will conflict with account names created by Microsoft Managed Desktop. Work with your Microsoft account representative to exclude these account names as we don't list the account names publicly to minimize security risk. 
 
 
 ### Security administrator roles

--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -277,13 +277,13 @@ A number of licenses are required to use Microsoft Managed Desktop.
 You don't have all the licenses you need to use Microsoft Managed Desktop. For more information, see [Microsoft Managed Desktop technologies](../intro/technologies.md) and [More about licenses](prerequisites.md#more-about-licenses).
 
 
-### Security account names
+### Microsoft Managed Desktop service accounts
 
-Certain security account names could conflict with ones created by Microsoft Managed Desktop.
+Certain accounts names could conflict with ones created by Microsoft Managed Desktop to manage the Microsoft Managed Desktop service.
 
 **Not ready**
 
-You have at least one account name that will conflict with ones created by Microsoft Managed Desktop. Work with your Microsoft account representative to exclude these account names.
+You have at least one account name that will conflict with ones created by Microsoft Managed Desktop. Work with your Microsoft account representative to exclude these account names as we don't list the accounts names publicly to minimiize security risk. 
 
 
 ### Security administrator roles

--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -279,7 +279,7 @@ You don't have all the licenses you need to use Microsoft Managed Desktop. For m
 
 ### Microsoft Managed Desktop service accounts
 
-Certain accounts names could conflict with ones created by Microsoft Managed Desktop to manage the Microsoft Managed Desktop service.
+Certain account names could conflict with account names created by Microsoft Managed Desktop to manage the Microsoft Managed Desktop service.
 
 **Not ready**
 

--- a/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
+++ b/microsoft-365/managed-desktop/get-ready/readiness-assessment-fix.md
@@ -283,7 +283,7 @@ Certain account names could conflict with account names created by Microsoft Man
 
 **Not ready**
 
-You have at least one account name that will conflict with account names created by Microsoft Managed Desktop. Work with your Microsoft account representative to exclude these account names as we don't list the account names publicly to minimize security risk. 
+You have at least one account name that will conflict with account names created by Microsoft Managed Desktop. Work with your Microsoft account representative to exclude these account names. We don't list the account names publicly to minimize security risk. 
 
 
 ### Security administrator roles


### PR DESCRIPTION
Changed the name of one of the checks, Security account names, to match the title of the check in ART-- which is called, Microsoft Managed Desktop service accounts. I also added wording to explain why we don't just tell them in this doc which account names they need to remedy, as listing them here would increase security risk for a malicious acting who can target that now known user account name.

@jaimeo , as always, I value your input on whether the wording I used is appropriate/easy to read. Thanks, Jaime!