### PR TITLE
note for Attack Simulator v1 retirement

### DIFF
--- a/microsoft-365/security/office-365-security/attack-simulator.md
+++ b/microsoft-365/security/office-365-security/attack-simulator.md
@@ -34,7 +34,7 @@ If your organization has Microsoft Defender for Office 365 Plan 2, which include
 
 > [!NOTE]
 > Attack Simulator v1 experience has been switched to read-only mode and replaced by Attack simulator training that's described in [Get started using Attack simulation training](attack-simulation-training-get-started.md).
-> The ability to launch new simulations from this site has been disabled. However, you can still access your reports for simulations run in the past 90 days.
+> The ability to launch new simulations from this site has been disabled. However, you can still access reports for simulations run for a period of 90 days from January 24, 2021.
 
 ## What do you need to know before you begin?
 

--- a/microsoft-365/security/office-365-security/attack-simulator.md
+++ b/microsoft-365/security/office-365-security/attack-simulator.md
@@ -32,6 +32,10 @@ ms.prod: m365-security
 
 If your organization has Microsoft Defender for Office 365 Plan 2, which includes [Threat Investigation and Response capabilities](office-365-ti.md), you can use Attack Simulator in the Security & Compliance Center to run realistic attack scenarios in your organization. These simulated attacks can help you identify and find vulnerable users before a real attack impacts your bottom line. Read this article to learn more.
 
+> [!NOTE]
+> Attack Simulator v1 experience has been switched to read-only mode and replaced by Attack simulator training that's described in [Get started using Attack simulation training](attack-simulation-training-get-started.md).
+> The ability to launch new simulations from this site has been disabled. However, you can still access your reports for simulations run in the past 90 days.
+
 ## What do you need to know before you begin?
 
 - To open the Security & Compliance Center, go to <https://protection.office.com/>. Attack simulator is available at **Threat management** \> **Attack simulator**. Go go directly to attack simulator, open <https://protection.office.com/attacksimulator>.


### PR DESCRIPTION
Suggesting a note be added mentioning Attack Simulator v1 is now retired and switched to read-only mode.
This was previously announced to O365 admins via:

MC230717, Plan for change, Published date: Dec 18, 2020
Major: Retirement
Timing: January 24, 2021
Action: use Attack Simulation Training located at https://security.microsoft.com

How this will affect your organization:

You are receiving this message because our reporting indicates one or more users in your organization are using Attack Simulator at https://protection.office.com.
Beginning January 24, 2021 Attack Simulator will enter read only mode. You will not be able to launch new simulations, however you will be able to access reports and export the data for simulations you have run for a period of 90 days from January 24, 2021.
New simulations can be launched from Attack Simulation Training located at https://security.microsoft.com.