### PR TITLE
Removing Tag Contributor role from documentation

### DIFF
--- a/microsoft-365/security/office-365-security/user-tags.md
+++ b/microsoft-365/security/office-365-security/user-tags.md
@@ -55,7 +55,7 @@ This article explains how to configure user tags in the Security & Compliance Ce
   **Notes**:
 
   - Adding users to the corresponding Azure Active Directory role in the Microsoft 365 admin center gives users the required permissions in the Security & Compliance Center _and_ permissions for other features in Microsoft 365. For more information, see [About admin roles](../../admin/add-users/about-admin-roles.md).
-  - User tag management is controlled by the **Tag Reader**, **Tag Contributor**, and **Tag Manager** roles.
+  - User tag management is controlled by the **Tag Reader** and **Tag Manager** roles.
 
 - You can also manage and monitor priority accounts in the Microsoft 365 admin center. For instructions, see [Manage and monitor priority accounts](../../admin/setup/priority-accounts.md).
 


### PR DESCRIPTION
We are unable to support the Tag Contributor role at this time. Removing it from the documentation for now.

@chrisda FYI.