### PR TITLE
Update use-notifications-and-policy-tips.md

### DIFF
--- a/microsoft-365/compliance/use-notifications-and-policy-tips.md
+++ b/microsoft-365/compliance/use-notifications-and-policy-tips.md
@@ -213,7 +213,7 @@ Currently, Outlook 2013 and later supports showing policy tips only for these co
 - Content contains
 - Content is shared
 
-Note that all of these conditions work in Outlook, where they will match content and enforce protective actions on content. But showing policy tips to users is not yet supported.
+Note that Exceptions are considered conditions and all of these conditions work in Outlook, where they will match content and enforce protective actions on content. But showing policy tips to users is not yet supported. 
   
 ### Policy tips in the Exchange admin center vs. the Security &amp; Compliance Center
 


### PR DESCRIPTION
Added a line stating Exceptions are considered conditions -Per testing implementing a DLP policy with exception that is not content contains or content is shared it prevents the policy tip from appearing. Maybe we could re-word this a little bit, but this information is correct and could cause ambiguity.