### PR TITLE
Update prerequisites.md

### DIFF
--- a/microsoft-365/security/mtp/prerequisites.md
+++ b/microsoft-365/security/mtp/prerequisites.md
@@ -45,9 +45,6 @@ Any of these licenses gives you access to Microsoft 365 Defender features in Mic
 - Microsoft Cloud App Security
 - Defender for Office 365 (Plan 2)
 
-> [!NOTE]
-> Trial licenses for Office 365 currently do not provide access to Microsoft 365 Defender.
-
 For more information, [view the Microsoft 365 Enterprise service plans](https://www.microsoft.com/licensing/product-licensing/microsoft-365-enterprise).
 
 > Don't have license yet? [Try or buy a Microsoft 365 subscription](https://docs.microsoft.com/microsoft-365/commerce/try-or-buy-microsoft-365?view=o365-worldwide)


### PR DESCRIPTION
M365D licenses have been updated last week, and M365D is available also for tenants whose only M365D related license is Office trial --> the note is not relevant anymore.
Can you help me find more places in docs that we have this comment?

Thanks!
Matika