### PR TITLE
Update enable-the-report-phish-add-in.md

### DIFF
--- a/microsoft-365/security/office-365-security/enable-the-report-phish-add-in.md
+++ b/microsoft-365/security/office-365-security/enable-the-report-phish-add-in.md
@@ -44,7 +44,7 @@ If you're a global administrator or an Exchange Online administrator, and Exchan
 
   - Outlook on the web
   - Outlook 2013 SP1 or later
-  - Outlook 2016 for Mac
+  - Outlook 2016 for Mac or later
   - Outlook included with Microsoft 365 apps for Enterprise
   - Outlook app for iOS and Android
 


### PR DESCRIPTION
Added outlook 2016 for mac or later as the feature is supported in 2019 as well. The Add-in shows support for Outlook 2016 or later on Mac" in the Office store as well.