### PR TITLE
Update managing-jobs-ediscovery20.md

### DIFF
--- a/microsoft-365/compliance/managing-jobs-ediscovery20.md
+++ b/microsoft-365/compliance/managing-jobs-ediscovery20.md
@@ -49,6 +49,6 @@ The following table describes the different status states for jobs.
 | Submission failed | The job submission failed.  You should attempt to rerun the action that triggered the job. |
 | In progress | The job is in progress, you can monitor the progress of the job in the **Jobs** tab. |
 | Successful | The job was successfully completed. The date and time that the job completed is displayed in the **Completed** column on the **Jobs** tab. |
-| Partially successful | The job was partially successful. This status is typically returned when the job didn't find any partially indexed data (also called *unindexed data*) in some of the custodian data sources.  |
+| Partially successful | The job was successful. This status is typically returned when the job didn't find any partially indexed data (also called *unindexed data*) in some of the custodian data sources.  |
 | Failed | The job failed.  You should attempt to rerun the action that triggered the job. If the job fails a second time, we recommend that you contact Microsoft Support and provide the support information from the job. |
 |||


### PR DESCRIPTION
The "Partially Successful" status is confusing to many clients because it is synonymous to "not entirely successful".  I suggest to change the description to state that this means that the job was in fact Successful. The word Partially indicates that no partially indexed items were found.