### PR TITLE
Update allow-members-to-send-as-or-send-on-behalf-of-group.md

### DIFF
--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -1,5 +1,5 @@
 ---
-title: "Allow users to send as or send on behalf of a group"
+title: "Allow members to send as or send on behalf of a group"
 ms.reviewer: arvaradh
 f1.keywords: NOCSH
 ms.author: mikeplum
@@ -19,7 +19,10 @@ ms.assetid: 0ad41414-0cc6-4b97-90fb-06bec7bcf590
 description: "Learn how to allow users to send email as a Microsoft 365 group or send email on behalf of a Microsoft 365 group."
 ---
 
-# Allow users to send as or send on behalf of a group
+# Allow members to send as or send on behalf of a group
+
+> [!Note]
+> Guests who are members of the group cannot be granted to send as or send on behalf of a group
 
 A member of a Microsoft 365 group who has been granted **Send as** or **Send on behalf** permissions can send email as the group, or on behalf of the group. This article explains how a global or Exchange administrator can set these permissions.
   
@@ -33,7 +36,7 @@ The **Send on Behalf** permission lets a user send email on behalf of a Microsof
 > [!TIP]
 > See [Send email from or on behalf of a Microsoft 365 group](https://support.microsoft.com/office/0f4964af-aec6-484b-a65c-0434df8cdb6b) to learn how to use Outlook and Outlook on the Web to send email from a group.
     
-## Allow users to send email as a group
+## Allow members to send email as a group
 
 This section explains how to allow users to send email as a group in the [Exchange admin center](https://go.microsoft.com/fwlink/p/?linkid=2059104) (EAC) in Exchange Online.
   
@@ -51,7 +54,7 @@ This section explains how to allow users to send email as a group in the [Exchan
     
     ![Type to search or pick a user from the list](../media/522919cf-664c-4a25-8076-c51c8c9fbe43.png)
   
-## Allow users to send email on behalf of a group
+## Allow members to send email on behalf of a group
 
 This section explains how to allow users to send email on behalf of a group in the Exchange admin center (EAC) in Exchange Online.
   

--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -1,5 +1,5 @@
 ---
-title: "Allow Users to send as or send on behalf of a Group"
+title: "Allow users to send as or send on behalf of a group"
 ms.reviewer: arvaradh
 f1.keywords: NOCSH
 ms.author: mikeplum

--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -1,5 +1,5 @@
 ---
-title: "Allow members to send as or send on behalf of a Group"
+title: "Allow Users to send as or send on behalf of a Group"
 ms.reviewer: arvaradh
 f1.keywords: NOCSH
 ms.author: mikeplum
@@ -19,7 +19,7 @@ ms.assetid: 0ad41414-0cc6-4b97-90fb-06bec7bcf590
 description: "Learn how to allow members to send email as a Microsoft 365 group or send email on behalf of a Microsoft 365 group."
 ---
 
-# Allow members to send as or send on behalf of a group
+# Allow Users to send as or send on behalf of a group
 
 A member of a Microsoft 365 group who has been granted **Send as** or **Send on behalf** permissions can send email as the group, or on behalf of the group. This article explains how a global or Exchange administrator can set these permissions.
   
@@ -33,7 +33,7 @@ The **Send on Behalf** permission lets a user send email on behalf of a Microsof
 > [!TIP]
 > See [Send email from or on behalf of a Microsoft 365 group](https://support.microsoft.com/office/0f4964af-aec6-484b-a65c-0434df8cdb6b) to learn how to use Outlook and Outlook on the Web to send email from a group.
     
-## Allow members to send email as a group
+## Allow users to send email as a group
 
 This section explains how to allow users to send email as a group in the [Exchange admin center](https://go.microsoft.com/fwlink/p/?linkid=2059104) (EAC) in Exchange Online.
   
@@ -51,7 +51,7 @@ This section explains how to allow users to send email as a group in the [Exchan
     
     ![Type to search or pick a user from the list](../media/522919cf-664c-4a25-8076-c51c8c9fbe43.png)
   
-## Allow members to send email on behalf of a group
+## Allow users to send email on behalf of a group
 
 This section explains how to allow users to send email on behalf of a group in the Exchange admin center (EAC) in Exchange Online.
   

--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -16,15 +16,14 @@ ms.collection:
 search.appverid:
 - MET150
 ms.assetid: 0ad41414-0cc6-4b97-90fb-06bec7bcf590
-description: "Learn how to allow users to send email as a Microsoft 365 group or send email on behalf of a Microsoft 365 group."
+description: "Learn how to allow group members to send email as a Microsoft 365 group or send email on behalf of a Microsoft 365 group."
 ---
 
 # Allow members to send as or send on behalf of a group
 
-> [!NOTE]
-> Guests who are members of a Microsoft 365 group cannot be granted **Send as** or **Send on behalf** permissions for the group.
+A member of a Microsoft 365 group who has been granted **Send as** or **Send on behalf** permissions can send email as the group, or on behalf of the group. (Guests in the group cannot be granted these permissions.)
 
-A member of a Microsoft 365 group who has been granted **Send as** or **Send on behalf** permissions can send email as the group, or on behalf of the group. This article explains how a global or Exchange administrator can set these permissions.
+This article explains how a global or Exchange administrator can set these permissions.
   
 For example, if Megan Bowen is part of the **Training** Microsoft 365 group, and has **Send as** permissions on the group, if she sends an email as the group, it will look like the **Training** group sent the email. 
   

--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -21,7 +21,7 @@ description: "Learn how to allow users to send email as a Microsoft 365 group or
 
 # Allow members to send as or send on behalf of a group
 
-> [!Note]
+> [!NOTE]
 > Guests who are members of a Microsoft 365 group cannot be granted **Send as** or **Send on behalf** permissions for the group.
 
 A member of a Microsoft 365 group who has been granted **Send as** or **Send on behalf** permissions can send email as the group, or on behalf of the group. This article explains how a global or Exchange administrator can set these permissions.

--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -19,7 +19,7 @@ ms.assetid: 0ad41414-0cc6-4b97-90fb-06bec7bcf590
 description: "Learn how to allow users to send email as a Microsoft 365 group or send email on behalf of a Microsoft 365 group."
 ---
 
-# Allow Users to send as or send on behalf of a group
+# Allow users to send as or send on behalf of a group
 
 A member of a Microsoft 365 group who has been granted **Send as** or **Send on behalf** permissions can send email as the group, or on behalf of the group. This article explains how a global or Exchange administrator can set these permissions.
   

--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -22,7 +22,7 @@ description: "Learn how to allow users to send email as a Microsoft 365 group or
 # Allow members to send as or send on behalf of a group
 
 > [!Note]
-> Guests who are members of the group cannot be granted to send as or send on behalf of a group
+> Guests who are members of a Microsoft 365 group cannot be granted **Send as** or **Send on behalf** permissions for the group.
 
 A member of a Microsoft 365 group who has been granted **Send as** or **Send on behalf** permissions can send email as the group, or on behalf of the group. This article explains how a global or Exchange administrator can set these permissions.
   

--- a/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
+++ b/microsoft-365/solutions/allow-members-to-send-as-or-send-on-behalf-of-group.md
@@ -16,7 +16,7 @@ ms.collection:
 search.appverid:
 - MET150
 ms.assetid: 0ad41414-0cc6-4b97-90fb-06bec7bcf590
-description: "Learn how to allow members to send email as a Microsoft 365 group or send email on behalf of a Microsoft 365 group."
+description: "Learn how to allow users to send email as a Microsoft 365 group or send email on behalf of a Microsoft 365 group."
 ---
 
 # Allow Users to send as or send on behalf of a group


### PR DESCRIPTION
replaced members with users for the below reasons. verify and let me know if this is OK or should we just add a note about these two line items.

1) users can send emails as a group even without being a member of a group
2) not all members have access to send as and only internal users have that privilege.