### PR TITLE
Update set-password-expiration-policy.md

### DIFF
--- a/microsoft-365/admin/manage/set-password-expiration-policy.md
+++ b/microsoft-365/admin/manage/set-password-expiration-policy.md
@@ -38,7 +38,7 @@ description: "Learn how to set a password expiration policy for your organizatio
 
 This article is for people who set password expiration policy for a business, school, or nonprofit. To complete these steps, you need to sign in with your Microsoft 365 admin account. [What's an admin account?](../admin-overview/admin-overview.md).
 
-You must be a [global admin or password admin](../add-users/about-admin-roles.md) to perform these steps.
+You must be a [global admin](../add-users/about-admin-roles.md) to perform these steps.
 
 If you're a user, you don't have the permissions to set your password to never expire. Ask your work or school technical support to do the steps in this article for you.
 
@@ -50,9 +50,7 @@ As an admin, you can make user passwords expire after a certain number of days, 
 > By default, passwords are set to expire in 90 days. Current research strongly indicates that mandated password changes do more harm than good. They drive users to choose weaker passwords, re-use passwords, or update old passwords in ways that are easily guessed by hackers. If setting password to never expire, we recommend enabling [multi-factor authentication](../security-and-compliance/set-up-multi-factor-authentication.md).
 
 Follow the steps below if you want to set user passwords to expire after a specific amount of time.
-> [!IMPORTANT]
-> Only [global admins](../add-users/about-admin-roles.md) can perform these steps.
-  
+
 1. In the admin center, go to the **Settings** \> **Org Settings**.
 
 2. Go to the <a href="https://go.microsoft.com/fwlink/p/?linkid=2072756" target="_blank">Security & privacy</a> page.


### PR DESCRIPTION
only global admin can perform these steps as Password admin don't have access to Org settings.

Also removed the important note which says only global admin make these changes as it is already mentioned in the document.