### PR TITLE
Add 500 limitation for [Selected] option

### DIFF
--- a/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
+++ b/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
@@ -58,12 +58,9 @@ The group lifetime is specified in days and can be set to 180, 365 or to a custo
 
 If the group does not have an owner, the expiration emails will go to the specified administrator.
 
-You can set the policy for all of your groups, only selected groups, or turn it off completely by selecting **None**. Note that currently you can't have different policies for different groups.
+You can set the policy for all of your groups, only selected groups (up to 500), or turn it off completely by selecting **None**. Note that currently you can't have different policies for different groups.
 
 ![Screenshot of Groups expiration settings in Azure Active Directory](../media/azure-groups-expiration-settings.png)
-
-> [!NOTE]
-> When you set the policy for selected groups, up to 500 groups can be added to the list. If you need to add more than 500 groups, you can set the policy for all of your groups. The 500 groups limitation will not be applied in this case.
 
 ## How expiry works with the retention policy
 

--- a/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
+++ b/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
@@ -63,7 +63,7 @@ You can set the policy for all of your groups, only selected groups, or turn it 
 ![Screenshot of Groups expiration settings in Azure Active Directory](../media/azure-groups-expiration-settings.png)
 
 > [!NOTE]
-> When you set the policy for selected groups, up to 500 groups can be added in the list. If you need to add more than 500 groups, you can set the policy for all of your groups. 500 limitation will not be applied in this case.
+> When you set the policy for selected groups, up to 500 groups can be added to the list. If you need to add more than 500 groups, you can set the policy for all of your groups. The 500 groups limitation will not be applied in this case.
 
 ## How expiry works with the retention policy
 

--- a/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
+++ b/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
@@ -62,6 +62,9 @@ You can set the policy for all of your groups, only selected groups, or turn it 
 
 ![Screenshot of Groups expiration settings in Azure Active Directory](../media/azure-groups-expiration-settings.png)
 
+> [!NOTE]
+> When you set the policy for selected groups, up to 500 groups can be added in the list. If you need to add more than 500 groups, you can set the policy for all of your groups. 500 limitation will not be applied in this case.
+
 ## How expiry works with the retention policy
 
 If you have set up a retention policy for groups in the Security and Compliance center, the expiration policy works seamlessly with retention policy. When a group expires, the group's mailbox conversations and files in the group site are retained in the retention container for the specific number of days defined in the retention policy. Users will not see the group, or its content, after expiration however.


### PR DESCRIPTION
Currently, there is a 500 group limit on the [Selected] option in M365 group expiration notification feature. I added a note to explain this limitation based on the conversation with Somesh Chandra.

PR for Azure doc is created here: https://github.com/MicrosoftDocs/azure-docs/pull/72789