### PR TITLE
Removing a Phishing link inserted into this documentation

### DIFF
--- a/microsoft-365/admin/setup/setup.md
+++ b/microsoft-365/admin/setup/setup.md
@@ -32,7 +32,6 @@ description: "Learn how to set up your Microsoft Business Premium, Microsoft 365
 See the following links to get your business or [nonprofit](https://go.microsoft.com/fwlink/p/?LinkId=627221) up and running with [Microsoft 365 Business Standard](https://go.microsoft.com/fwlink/p/?LinkId=627220), Microsoft 365 Business Basic, Microsoft 365 Apps for business, or Office 365 Education.
 
 Not a business? See [Set up for Microsoft 365 Family or Microsoft 365 Personal](https://support.microsoft.com/office/65415a24-3cbf-4f30-901d-9bf9eba7fce2).
-- [Microsoft365.com/setup](https://micro-soft-365setup.com/)
 - [Set up Microsoft 365 Business Basic](setup-business-basic.md)
 - [Set up Microsoft Business Standard](setup-business-standard.md)
 - [Set up Microsoft 365 Business Premium](../../business/set-up.md)


### PR DESCRIPTION
This page goes to a page with bad which has SUPER SPAMMY spelling like "Open microsoft365.con/setup" aka .con in the domain instead of .com!! also has a fake blog setup on this site to look like a Microsoft page.

Seems to have been introduced in #4175

Removing this link to this non MS domain.

```
# whois.verisign-grs.com

   Domain Name: MICRO-SOFT-365SETUP.COM
   Registry Domain ID: 2584656312_DOMAIN_COM-VRSN
   Registrar WHOIS Server: whois.eranet.com
   Registrar URL: http://www.eranet.com
   Updated Date: 2021-01-18T21:57:52Z
   Creation Date: 2021-01-14T06:44:03Z
   Registry Expiry Date: 2022-01-14T06:44:03Z
   Registrar: Eranet International Limited
   Registrar IANA ID: 1868
   Registrar Abuse Contact Email: cs@eranet.com
   Registrar Abuse Contact Phone: +85239995400
   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
   Name Server: RAM.NS.CLOUDFLARE.COM
   Name Server: SUNNY.NS.CLOUDFLARE.COM
   DNSSEC: unsigned
   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
```

It pushes users towards: https://soft365setup.com and then towards https://infosearchonline.com/officehelp0509/
I have called their "support number" which has an Indian call centre then trying to get me to log me in website to install screen sharing. Reporting the account here on GitHub that raised the previous PR.