### PR TITLE
Update manage-creation-of-groups.md

### DIFF
--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -38,7 +38,7 @@ When you limit who can create a group, it affects all services that rely on grou
 - Power BI (classic)
 - Project for the web / Roadmap
 
-The steps in this article won't prevent members of certain roles from creating Groups. Office 365 Global admins can create Groups via any means, such as the Microsoft 365 admin center, Planner, Teams, Exchange, and SharePoint Online. Other roles can create Groups via limited means, listed below.
+The steps in this article won't prevent members of certain roles from creating Groups. Office 365 Global admins can create Groups via  Microsoft 365 admin center, Planner,  Exchange, and SharePoint Online. Other roles can create Groups via limited means, listed below.
 
 - Exchange Administrator: Exchange Admin center, Azure AD
 - Partner Tier 1 Support: Microsoft 365 Admin center, Exchange Admin center, Azure AD

--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -38,7 +38,7 @@ When you limit who can create a group, it affects all services that rely on grou
 - Power BI (classic)
 - Project for the web / Roadmap
 
-The steps in this article won't prevent members of certain roles from creating Groups. Office 365 Global admins can create Groups via  Microsoft 365 admin center, Planner,  Exchange, and SharePoint Online. Other roles can create Groups via limited means, listed below.
+The steps in this article won't prevent members of certain roles from creating Groups. Office 365 Global admins can create Groups via the Microsoft 365 admin center, Planner, Exchange, and SharePoint Online. Other roles can create Groups via limited means, listed below.
 
 - Exchange Administrator: Exchange Admin center, Azure AD
 - Partner Tier 1 Support: Microsoft 365 Admin center, Exchange Admin center, Azure AD


### PR DESCRIPTION
GA can only create groups via EAC, O365 Admin center, Planner and SPO. Teams and Outlook/owa does not let them create it when the restrictions are in place.