### PR TITLE
Move limits from export section over to review set

### DIFF
--- a/microsoft-365/compliance/limits-ediscovery20.md
+++ b/microsoft-365/compliance/limits-ediscovery20.md
@@ -31,10 +31,12 @@ The following table lists the limits for cases and review sets in Advanced eDisc
 |Total number of documents that can be added to a case (for all review sets in a case).  <br/> |3 million <br/> |
 |Total file size per load set. This includes loading non-Office 365 into a review set.  <br/> |300 GB <br/> |
 |Total amount of data loaded into all review sets in the organization per day.<br/> |2 TB <br/> |
-|Maximum number of loads sets per case.  <br/> |200 <br/> |
+|Maximum number of load sets per case.  <br/> |200 <br/> |
 |Maximum number of review sets per case.  <br/> |20 <br/> |
 |Maximum number of tag groups per case.  <br/> |1000 <br/> |
 |Maximum number of tags per case.  <br/> |1000 <br/> |
+|Maximum concurrent exports (add to Review Set jobs) in your organization. | 10 <sup>4</sup> |
+|Maximum concurrent exports (add to REview Set jobs) per user. | 3 |
 |||
 
 ## Hold limits
@@ -102,15 +104,11 @@ Microsoft collects performance information for searches run by all organizations
 |Maximum size of Excel file that can be viewed in the native viewer.  <br/> |4 MB  <br/> |
 |||
 
-## Export limits
+## Export limits - Final export out of Review Set
 
 | Description of limit | Limit |
 |:-----|:-----|
 |Maximum size of a single export.|3 million documents or 100 GB, whichever is smaller|
-|Maximum amount of data in a single day. | 2 TB |
-|Maximum concurrent exports in your organization. | 10 <sup>4</sup> |
-|Maximum concurrent exports per user. | 3 |
-|Maximum size of a single PST file. | 10 GB |
 |Maximum concurrent exports per review set. | 1 |
 |||
 

--- a/microsoft-365/compliance/limits-ediscovery20.md
+++ b/microsoft-365/compliance/limits-ediscovery20.md
@@ -35,8 +35,8 @@ The following table lists the limits for cases and review sets in Advanced eDisc
 |Maximum number of review sets per case.  <br/> |20 <br/> |
 |Maximum number of tag groups per case.  <br/> |1000 <br/> |
 |Maximum number of tags per case.  <br/> |1000 <br/> |
-|Maximum concurrent exports (add to Review Set jobs) in your organization. | 10 <sup>4</sup> |
-|Maximum concurrent exports (add to REview Set jobs) per user. | 3 |
+|Maximum concurrent jobs in your organization to add content to a review set. These jobs are named **Adding data to a review set** and are displayed on the **Jobs** tab in a case.| 10 <sup>4</sup> |
+|Maximum concurrent jobs to add content to a review set per user. These jobs are named **Adding data to a review set** and are displayed on the **Jobs** tab in a case. | 3 |
 |||
 
 ## Hold limits
@@ -106,6 +106,8 @@ Microsoft collects performance information for searches run by all organizations
 
 ## Export limits - Final export out of Review Set
 
+The limits described in this section are related to exporting documents out of a review set.
+
 | Description of limit | Limit |
 |:-----|:-----|
 |Maximum size of a single export.|3 million documents or 100 GB, whichever is smaller|
@@ -129,7 +131,7 @@ Microsoft collects performance information for searches run by all organizations
 >
 > <sup>3</sup> For non-phrase queries (a keyword value that doesn't use double quotation marks) we use a special prefix index. This tells us that a word occurs in a document, but not where it occurs in the document. To do a phrase query (a keyword value with double quotation marks), we need to compare the position within the document for the words in the phrase. This means that we can't use the prefix index for phrase queries. In this case, we internally expand the query with all possible words that the prefix expands to; for example,  **time\*** can expand to  **"time OR timer OR times OR timex OR timeboxed OR …"**. The limit of 10,000 is the maximum number of variants the word can expand to, not the number of documents matching the query. There is no upper limit for non-phrase terms.
 >
-> <sup>4</sup> This limit is shared across all eDiscovery tools. This means that concurrent exports in Content search, Core eDiscovery, and Advanced eDiscovery are applied against this limit.
+> <sup>4</sup> This limit is shared with exporting content in other eDiscovery tools. This means that concurrent exports in Content search and Core eDiscovery (and adding content to review sets in Advanced eDiscovery) are all applied against this limit.
 >
 > <sup>5</sup> This limit applies to downloading selected documents from a review set. It doesn't apply to exporting documents from a review set. For more information about downloading and exporting documents, see [Export case data in Advanced eDiscovery](exporting-data-ediscover20.md).
 >


### PR DESCRIPTION
In AeD, there is a distinction between "add to review set" vs final export. The "Add to review set" job lines up with the export limits in Core eD and they need to be added to the Review Set limits. 

The export limits should only include limits related to exporting or downloading from Review set. Please make distinction clear between download and export.