### PR TITLE
Fix typo

### DIFF
--- a/microsoft-365/security/defender-endpoint/web-threat-protection.md
+++ b/microsoft-365/security/defender-endpoint/web-threat-protection.md
@@ -31,7 +31,7 @@ ms.technology: mde
 Web threat protection is part of [Web protection](web-protection-overview.md) in Defender for Endpoint. It uses [network protection](network-protection.md) to secure your devices against web threats. By integrating with Microsoft Edge and popular third-party browsers like Chrome and Firefox, web threat protection stops web threats without a web proxy and can protect devices while they are away or on premises. Web threat protection stops access to phishing sites, malware vectors, exploit sites, untrusted or low-reputation sites, as well as sites that you have blocked in your [custom indicator list](manage-indicators.md).
 
 >[!Note]
->It can take up to an hour for devices to receive new customer indicators.
+>It can take up to an hour for devices to receive new custom indicators.
 
 ## Prerequisites
 Web protection uses network protection to provide web browsing security on Microsoft Edge and third-party web browsers.


### PR DESCRIPTION
I believe the reference to customer indicators instead meant to refer to custom indicators.