### PR TITLE
eDiscovery cannot search encrypted files content

### DIFF
--- a/microsoft-365/compliance/ediscovery-decryption.md
+++ b/microsoft-365/compliance/ediscovery-decryption.md
@@ -38,7 +38,7 @@ The following table identifies the supported tasks that can be performed in Micr
 
 |eDiscovery task  |Content search  |Core eDiscovery  |Advanced eDiscovery  |
 |:---------|:---------|:---------|:---------|
-|Search for content in encrypted files in email and sites     |Yes      |Yes      |Yes      |
+|Search for content in encrypted files in sites     |Yes      |Yes      |Yes      |
 |Preview encrypted files attached to email     |Yes      |Yes     |Yes       |
 |Preview encrypted documents in SharePoint and OneDrive|No      |No    |Yes       |
 |Review encrypted files in a review set    |N/A      |N/A        | Yes        |


### PR DESCRIPTION
Public reference is wrong. eDiscovery cannot search for content in encrypted files in Exchange. 
Confirmed by Engineering group:

"Hi @Juan Gasca,  from our investigation, the attachment failed to index. It throws PasswordProtectedError when parsing the attachment. We reached out to Doc Parsing team and they said such kind of error is by design. DocParser service won't parse encrypted attachment."

https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/2030667