### PR TITLE
Update get-all-vulnerabilities.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/get-all-vulnerabilities.md
+++ b/microsoft-365/security/defender-endpoint/get-all-vulnerabilities.md
@@ -33,7 +33,7 @@ ms.technology: mde
 
 [!include[Prerelease information](../../includes/prerelease.md)]
 
-Retrieves a list of all the vulnerabilities affecting the organization.
+Retrieves a list of all the vulnerabilities.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Use Microsoft Defender for Endpoint APIs](apis-intro.md) for details.


### PR DESCRIPTION
By removing the "affecting the organization" we make it clear that we do return  all vulnerabilities on our database and not the ones who apply to hosts on boarded.