### PR TITLE
Corrected inaccurate description of Sensitive by Default

### DIFF
--- a/microsoft-365/compliance/data-loss-prevention-policies.md
+++ b/microsoft-365/compliance/data-loss-prevention-policies.md
@@ -507,7 +507,7 @@ Finally, documents can conflict with a DLP policy, but they can also become comp
 DLP evaluates any content that can be indexed. For more information on what file types are crawled by default, see [Default crawled file name extensions and parsed file types in SharePoint Server](/SharePoint/technical-reference/default-crawled-file-name-extensions-and-parsed-file-types).
 
 > [!NOTE]
-> External sharing of new files in SharePoint can be blocked by default until at least one DLP policy scans the new item. See, [Mark new files as sensitive by default](/sharepoint/sensitive-by-default) for detailed information. 
+> In order to prevent documents from being shared before DLP policies had the opportunity to analyze them, sharing of new files in SharePoint can be blocked until its content has been indexed. See, [Mark new files as sensitive by default](/sharepoint/sensitive-by-default) for detailed information. 
   
 ### Policy evaluation in Exchange Online, Outlook, and Outlook on the web
 


### PR DESCRIPTION
Original description says SBD blocks files from being shared until at least one DLP policy scans the new item. This is incorrect, since DLP doesn't do the scanning, and lack of indexing won't prevent DLP from evaluating the document. SBD actually works by blocking access to files until they have been *indexed*, which in turns enables DLP policies to accurately assess the document.