### PR TITLE
Update troubleshooting doc to match

### DIFF
--- a/microsoft-365/security/defender-endpoint/troubleshoot-onboarding.md
+++ b/microsoft-365/security/defender-endpoint/troubleshoot-onboarding.md
@@ -287,8 +287,9 @@ If the verification fails and your environment is using a proxy to connect to th
     ![Image of registry key for Microsoft Defender Antivirus](images/atp-disableantispyware-regkey.png)
 
    > [!NOTE]
-   > In addition, you must ensure that wdfilter.sys and wdboot.sys are set to their default start values of "0".
+   > All Windows Defender services (wdboot, wdfilter, wdnisdrv, wdnissvc, and windefend) should be in their default state. Changing the startup of these services is unsupported and may force you to reimage your system.
    >
+   > Example default configurations for WdBoot and WdFilter:
    > - `<Key Path="SYSTEM\CurrentControlSet\Services\WdBoot"><KeyValue Value="0" ValueKind="DWord" Name="Start"/></Key>`
    > - `<Key Path="SYSTEM\CurrentControlSet\Services\WdFilter"><KeyValue Value="0" ValueKind="DWord" Name="Start"/></Key>`
 


### PR DESCRIPTION
We have conflicting statements on support for service configuration in Defender. Updating to match https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/troubleshoot-microsoft-defender-antivirus-when-migrating?view=o365-worldwide