### PR TITLE
Teams DLP scopping for SG/DL now GA

### DIFF
--- a/microsoft-365/compliance/dlp-microsoft-teams.md
+++ b/microsoft-365/compliance/dlp-microsoft-teams.md
@@ -107,7 +107,7 @@ To perform this task, you must be assigned a role that has permissions to edit D
 5. On the **Choose locations** tab, keep the default setting of all accounts, or select **Let me choose specific locations**. You can specify:
 
     1. up to 1000 individual accounts to include or exclude
-    1. distribution lists and security groups to include or exclude. **This is a public preview feature.**
+    1. distribution lists and security groups to include or exclude. 
     <!-- 1. the shared mailbox of a shared channel. **This is a public preview feature.**--> 
     
 6. Then choose **Next**.


### PR DESCRIPTION
Teams DLP scopping for SG/DL seem now GA, so no more in Public Preview: https://techcommunity.microsoft.com/t5/security-compliance-identity/microsoft-further-extends-unified-data-loss-prevention/ba-p/2166321