### PR TITLE
Adding size limit to Fingerprint documentation

### DIFF
--- a/microsoft-365/compliance/document-fingerprinting.md
+++ b/microsoft-365/compliance/document-fingerprinting.md
@@ -57,6 +57,7 @@ Document Fingerprinting won't detect sensitive information in the following case
 - Password protected files
 - Files that contain only images
 - Documents that don't contain all the text from the original form used to create the document fingerprint
+- Files greater than 10 MB
 
 ## Use PowerShell to create a classification rule package based on document fingerprinting
 


### PR DESCRIPTION
@chrfox - currently, there are no size limitations listed in Fingerpring documentation. I have edited the document to include it. Please review & publish.