### PR TITLE
Update groups-teams-compliance-governance.md

### DIFF
--- a/microsoft-365/solutions/groups-teams-compliance-governance.md
+++ b/microsoft-365/solutions/groups-teams-compliance-governance.md
@@ -55,7 +55,7 @@ User chats are retained indefinitely even if a user account is deleted. If you d
 
 - [Retention policies in Microsoft Teams](/microsoftteams/retention-policies)
 
-A single retention policy can be set to apply to Microsoft 365 Groups, Teams chat, and Teams channel messages. 
+A single retention policy can be set to apply to Teams chat, and Teams channel messages. 
 
 Additional resources:
 

--- a/microsoft-365/solutions/groups-teams-compliance-governance.md
+++ b/microsoft-365/solutions/groups-teams-compliance-governance.md
@@ -55,7 +55,7 @@ User chats are retained indefinitely even if a user account is deleted. If you d
 
 - [Retention policies in Microsoft Teams](/microsoftteams/retention-policies)
 
-A single retention policy can be set to apply to Teams chat, and Teams channel messages. 
+A single retention policy can be set to apply to Teams chat and Teams channel messages. 
 
 Additional resources:
 


### PR DESCRIPTION
A single retention policy can be set to apply to Teams chat, and Teams channel messages. When you add M365 Group, Teams chat and/or channel message cannot be selected.