### PR TITLE
change in data center location for ASC tenants

### DIFF
--- a/microsoft-365/security/defender/m365d-enable.md
+++ b/microsoft-365/security/defender/m365d-enable.md
@@ -60,7 +60,7 @@ Microsoft 365 Defender will store and process data in the [same location used by
 Select **Need help?** in the Microsoft 365 security center to contact Microsoft support about provisioning Microsoft 365 Defender in a different data center location.
 
 > [!NOTE]
-> Microsoft Defender for Endpoint automatically provisions in European Union (EU) data centers when turned on through Azure Defender. Microsoft 365 Defender will automatically provision in the same EU data center for customers who have provisioned Defender for Endpoint in this manner.
+> in the past, Microsoft Defender for Endpoint automatically used to be provisioned European Union (EU) data centers when turned on through Azure Defender. Microsoft 365 Defender will automatically provision in the same EU data center for customers who have provisioned Defender for Endpoint in this manner.
 
 ### Confirm that the service is on
 

--- a/microsoft-365/security/defender/m365d-enable.md
+++ b/microsoft-365/security/defender/m365d-enable.md
@@ -60,7 +60,7 @@ Microsoft 365 Defender will store and process data in the [same location used by
 Select **Need help?** in the Microsoft 365 security center to contact Microsoft support about provisioning Microsoft 365 Defender in a different data center location.
 
 > [!NOTE]
-> in the past, Microsoft Defender for Endpoint automatically used to be provisioned European Union (EU) data centers when turned on through Azure Defender. Microsoft 365 Defender will automatically provision in the same EU data center for customers who have provisioned Defender for Endpoint in this manner.
+> In the past, Microsoft Defender for Endpoint automatically provisioned in European Union (EU) data centers when turned on through Azure Defender. Microsoft 365 Defender will automatically provision in the same EU data center for customers who have provisioned Defender for Endpoint in this manner in the past.
 
 ### Confirm that the service is on
 


### PR DESCRIPTION
in the past (until a few months ago), is MDE was enabled for the first time via the integration with Azure defender, the data location for MDE data was hardcoded EU. 
we changed it a few months ago, and today we use the same methodology to choose the data center location as all other tenants. 
contact me for more details