### PR TITLE
Simplified Apps in MMD

### DIFF
--- a/microsoft-365/managed-desktop/get-ready/apps.md
+++ b/microsoft-365/managed-desktop/get-ready/apps.md
@@ -22,8 +22,7 @@ audience: Admin
 
 Microsoft includes certain key apps along with the Microsoft 365 E3 or E5 license needed to participate in Microsoft Managed Desktop. However, even though we provide these apps, you still have certain responsibilities and actions to complete.
 
-You can also deploy additional non-Microsoft apps to your users for self-service through the Company Portal or a required background installation, all using Microsoft Intune’s deployment pipeline. If you have the expertise, you can migrate those apps you need yourself; alternatively, Microsoft Consulting Services (MCS) or non-Microsoft vendors will be happy to help you with a packaging and migration project. For more information about working with MCS, see [Working with Microsoft Consulting Services](apps-MCS.md).
-
+You can also deploy additional non-Microsoft apps to your users for self-service through the Company Portal or a required background installation, all using Microsoft Intune’s deployment pipeline. 
 
 ## Apps provided by Microsoft
 
@@ -43,10 +42,7 @@ There are still certain things you need to do with these apps:
 
 ## Apps you provide
 
-You probably have other apps you need for your business operations. These apps can only be deployed to Microsoft Managed Desktop devices by using Microsoft Intune’s deployment pipeline. If the app needs it you can have them packaged by a vendor (which could be a non-Microsoft vendor or Microsoft Consulting Services (MCS)) or if you have the means, you can package them yourself. You then add these packages to the Microsoft Managed Desktop portal and assign them to Azure Active Directory groups to trigger the deployment. 
-
-If you currently deploy your apps by using Microsoft Endpoint Configuration Manager, Microsoft Managed Desktop can provide you with a query to assess your apps and discover which ones are ready for to migrate to Microsoft Intune and which ones might require some adjustment.
-
+You probably have other apps you need for your business operations. These apps can only be deployed to Microsoft Managed Desktop devices by using Microsoft Intune’s deployment pipeline. For more information about application deployment follow the steps in [Deploy apps to Microsoft Managed Desktop devices](../get-started/deploy-apps.md).
 
 ### Preparing your own apps for inclusion in Microsoft Managed Desktop
 Review your apps, checking:
@@ -54,24 +50,6 @@ Review your apps, checking:
 - None of the apps are prohibited or have restricted behavior, as described in [Microsoft Managed Desktop app requirements](../service-description/mmd-app-requirements.md).
 - Apps must be ready for management by Microsoft Intune. For more about this topic, see [Windows 10 app deployment using Microsoft Intune](/intune/apps-windows-10-app-deploy) and [Add apps to Microsoft Intune](/intune/apps-add).
 - Other pre-packaging requirements such as providing license keys, agreement with license terms, and pre-setting server connections.
-
-### Decide how to package apps
-
-Some independent software publishers might require that your apps are packaged before they are centrally deployed. “Packaging” means that the app’s installer is configured with settings like license keys, remote server locations, or desktop shortcuts so that the app can be installed in the background.
-
-There are three options to get your apps packaged: 
-
-
-- You can package apps yourself
-- You can work with a non-Microsoft vendor
-- You can engage with MCS to package your apps. Work with your Microsoft account representative. For more information, see [Working with Microsoft Consulting Services](apps-MCS.md).
-
-
-
-## Deploying apps
-
-Whatever method you use to get apps packaged, once that is complete, you're ready to follow the steps in [Deploy apps to Microsoft Managed Desktop devices](../get-started/deploy-apps.md).
-
 
 ## Steps to get ready
 


### PR DESCRIPTION
Simplified the content to reflect the fact that the customer deploys apps through Microsoft Intune and have removed references to packaging since we will be depreciating that service.