### PR TITLE
Update document to reflect confidence level change

### DIFF
--- a/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
+++ b/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
@@ -56,15 +56,15 @@ Here's the sample XML of the rule package that we'll create in this topic. Eleme
 </RulePack>
 <Rules>
 <!-- Employee ID -->
-	<Entity id="E1CC861E-3FE9-4A58-82DF-4BD259EAB378" patternsProximity="300" recommendedConfidence="70">
-		<Pattern confidenceLevel="60">
+	<Entity id="E1CC861E-3FE9-4A58-82DF-4BD259EAB378" patternsProximity="300" recommendedConfidence="75">
+		<Pattern confidenceLevel="65">
 			<IdMatch idRef="Regex_employee_id"/>
 		</Pattern>
-		<Pattern confidenceLevel="70">
+		<Pattern confidenceLevel="75">
 			<IdMatch idRef="Regex_employee_id"/>
 			<Match idRef="Func_us_date"/>
 		</Pattern>
-		<Pattern confidenceLevel="80">
+		<Pattern confidenceLevel="85">
 			<IdMatch idRef="Regex_employee_id"/>
 			<Match idRef="Func_us_date"/>
 			<Any minMatches="1">


### PR DESCRIPTION
There are few places where we are using 60, 70 & 80 as confidence levels which should be updated to 65, 75, 85. Also, we have certain screenshots in the document which are showing the older UI with confidence numbers while creating policies instead of the new UI with confidence levels. @chrfox - need your help in getting the images updated.