### PR TITLE
use /tmp for eicar download

### DIFF
--- a/microsoft-365/security/defender-endpoint/linux-install-manually.md
+++ b/microsoft-365/security/defender-endpoint/linux-install-manually.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy Microsoft Defender for Endpoint on Linux manually
-ms.reviewer: 
+ms.reviewer:
 description: Describes how to deploy Microsoft Defender for Endpoint on Linux manually from the command line.
 keywords: microsoft, defender, Microsoft Defender for Endpoint, linux, installation, deploy, uninstallation, puppet, ansible, linux, redhat, ubuntu, debian, sles, suse, centos
 search.product: eADQiWindows 10XVcnh
@@ -14,7 +14,7 @@ author: dansimp
 localization_priority: Normal
 manager: dansimp
 audience: ITPro
-ms.collection: 
+ms.collection:
   - m365-security-compliance
 ms.topic: conceptual
 ms.technology: mde
@@ -161,10 +161,10 @@ In order to preview new features and provide early feedback, it is recommended t
     sudo mv ./microsoft.list /etc/apt/sources.list.d/microsoft-[channel].list
     ```
     For example, if you chose *prod* channel:
-    
+
     ```bash
     sudo mv ./microsoft.list /etc/apt/sources.list.d/microsoft-prod.list
-    ```   
+    ```
 
 - Install the `gpg` package if not already installed:
 
@@ -336,7 +336,7 @@ Download the onboarding package from Microsoft Defender Security Center:
     - Open a Terminal window. Copy and execute the following command:
 
         ``` bash
-        curl -o ~/Downloads/eicar.com.txt https://www.eicar.org/download/eicar.com.txt
+        curl -o /tmp/eicar.com.txt https://www.eicar.org/download/eicar.com.txt
         ```
 
     - The file should have been quarantined by Defender for Endpoint on Linux. Use the following command to list all the detected threats:


### PR DESCRIPTION
As pointed out by @mifurm, `~/Downloads/` most likely won't exist on a Linux system.
This PR changes the directory to `/tmp`.

Closes #4869 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>