### PR TITLE
Update safe-links.md

### DIFF
--- a/microsoft-365/security/office-365-security/safe-links.md
+++ b/microsoft-365/security/office-365-security/safe-links.md
@@ -55,8 +55,6 @@ Safe Links protection is available in the following locations:
 
 - **Office 365 apps**: Safe Links protection for Office 365 apps is available in supported desktop, mobile, and web aps. You **configure** Safe Links protection for Office 365 apps in the global setting that are **outside** of Safe Links policies. For instructions, see [Configure global settings for Safe Links settings in Microsoft Defender for Office 365](configure-global-settings-for-safe-links.md).
 
-  But, Safe Links protection for Office 365 apps is only **applied** to users who are included in active Safe Links policies. If a user isn't included in an active Safe Links policy, the user doesn't get Safe Links protection in supported Office 365 apps.
-
   For more information about Safe Links protection in Office 365 apps, see the [Safe Links settings for Office 365 apps](#safe-links-settings-for-office-365-apps) section later in this article.
 
 This article includes detailed descriptions of the following types of Safe Links settings:

--- a/microsoft-365/security/office-365-security/safe-links.md
+++ b/microsoft-365/security/office-365-security/safe-links.md
@@ -53,7 +53,9 @@ Safe Links protection is available in the following locations:
 
   For more information about Safe Links protection in Teams, see the [Safe Links settings for Microsoft Teams](#safe-links-settings-for-microsoft-teams) section later in this article.
 
-- **Office 365 apps**: Safe Links protection for Office 365 apps is available in supported desktop, mobile, and web aps. You **configure** Safe Links protection for Office 365 apps in the global setting that are **outside** of Safe Links policies. For instructions, see [Configure global settings for Safe Links settings in Microsoft Defender for Office 365](configure-global-settings-for-safe-links.md).
+- **Office 365 apps**: Safe Links protection for Office 365 apps is available in supported desktop, mobile, and web apps. You **configure** Safe Links protection for Office 365 apps in the global setting that are **outside** of Safe Links policies. For instructions, see [Configure global settings for Safe Links settings in Microsoft Defender for Office 365](configure-global-settings-for-safe-links.md).
+
+  Safe Links protection for Office 365 apps is applied to all users in the organization who are licensed for Defender for Office 365, regardless of whether the users are included in active Safe Links policies or not.
 
   For more information about Safe Links protection in Office 365 apps, see the [Safe Links settings for Office 365 apps](#safe-links-settings-for-office-365-apps) section later in this article.
 
@@ -72,6 +74,8 @@ This article includes detailed descriptions of the following types of Safe Links
 
 The following table describes scenarios for Safe Links in Microsoft 365 and Office 365 organizations that include Defender for Office 365 (in other words, lack of licensing is never an issue in the examples).
 
+<br>
+
 ****
 
 |Scenario|Result|
@@ -81,6 +85,7 @@ The following table describes scenarios for Safe Links in Microsoft 365 and Offi
 |In Pat's organization, no admins have created any Safe Links policies, but Safe Links protection for Office 365 apps is turned on. Pat opens a Word document and clicks a URL in the file.|Pat is not protected by Safe Links. <p> Although Safe Links protection for Office 365 apps is turned on globally, Pat is not included in any active Safe Links policies, so the protection can't be applied.|
 |In Lee's organization, `https://tailspintoys.com` is configured in the **Block the following URLs** list in the global settings for Safe Links. A Safe Links policy that includes Lee already exists. Lee receives an email message that contains the URL `https://tailspintoys.com/aboutus/trythispage`. Lee clicks the URL.|The URL might be automatically blocked for Lee; it depends on the URL entry in the list and the email client Lee used. For more information, see the ["Block the following URLs" list for Safe Links](#block-the-following-urls-list-for-safe-links) section later in this article.|
 |Jamie and Julia both work for contoso.com. A long time ago, admins configured Safe Links policies that apply to both of Jamie and Julia. Jamie sends an email to Julia, not knowing that the email contains a malicious URL.|Julia is protected by Safe Links **if** the Safe Links policy that applies to her is configured to apply to messages between internal recipients. For more information, see the [Safe Links settings for email messages](#safe-links-settings-for-email-messages) section later in this article.|
+|
 
 ## Safe Links settings for email messages
 
@@ -201,7 +206,7 @@ Safe Links protection for Office 365 apps has the following client requirements:
 
 - Users are signed in using their work or school accounts. For more information, see [Sign in to Office](https://support.microsoft.com/office/b9582171-fd1f-4284-9846-bdd72bb28426).
 
-You configure Safe Links protection for Office 365 apps in the global settings for Safe Links, not in Safe Links policies. But, in order for Safe Links protection for Office 365 apps to be applied, the user who opens the Office document and clicks the link must be included in an active Safe Links policy.
+You configure Safe Links protection for Office 365 apps in the global settings for Safe Links, not in Safe Links policies. The protection is applied to all users in the organization who are licensed for Defender for Office 365, regardless of whether the users are included in active Safe Links policies or not.
 
 The following Safe Links settings are available for Office 365 apps:
 


### PR DESCRIPTION
remove row 58 based on feedback from PG Feature PM Brian Wilcox, as this is not the case for Office 365 Apps, instead as soon as the setting is enabling its targeting everyone independent of the safelink policy scope.
-->  But, Safe Links protection for Office 365 apps is only **applied** to users who are included in active Safe Links policies. If a user isn't included in an active Safe Links policy, the user doesn't get Safe Links protection in supported Office 365 apps.