### PR TITLE
Update configure-exchange-server-for-hybrid-modern-authentication.md

### DIFF
--- a/microsoft-365/enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
+++ b/microsoft-365/enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
@@ -135,7 +135,7 @@ If OAuth is missing from any server and any of the four virtual directories, you
 Return to the on-premises Exchange Management Shell for this last command. Now you can validate that your on-premises has an entry for the evoSTS authentication provider:
 
 ```powershell
-Get-AuthServer | where {$_.Name -eq "EvoSts"}
+Get-AuthServer | where {$_.Name -like "EvoSts"}
 ```
 
 Your output should show an AuthServer of the Name EvoSts and the 'Enabled' state should be True. If you don't see this, you should download and run the most recent version of the Hybrid Configuration Wizard.


### PR DESCRIPTION
Changed it from Get-AuthServer | where {$_.Name -eq "EvoSts"} to  Get-AuthServer | where {$_.Name -like "EvoSts*"}

If the Exchange is HYbird it shows the auth server with a guide, like  EvoSts - {GUID}