### PR TITLE
Update use-dmarc-to-validate-email.md

### DIFF
--- a/microsoft-365/security/office-365-security/use-dmarc-to-validate-email.md
+++ b/microsoft-365/security/office-365-security/use-dmarc-to-validate-email.md
@@ -173,7 +173,7 @@ Examples:
     _dmarc.contoso.com  3600 IN  TXT  "v=DMARC1; p=reject"
     ```
 
-Once you have formed your record, you need to update the record at your domain registrar. For instructions on adding the DMARC TXT record to your DNS records for Microsoft 365, see [Create DNS records for Microsoft 365 when you manage your DNS records](../../admin/get-help-with-domains/create-dns-records-at-any-dns-hosting-provider.md).
+Once you have formed your record, you need to update the record at your domain registrar.
 
 ## Best practices for implementing DMARC in Microsoft 365
 


### PR DESCRIPTION
Removed instructions on adding DMARC record as it was pointing to a document which talks about adding MX and TXT records to connect your domain and nothing specific to DMARC. or another TXT record.

The document already contains instructions about forming DMARC records and best practices. So users will have to form the record and update it on their domain registrar for which the steps will be different depending on the host.