### PR TITLE
Update centralized-deployment-of-add-ins.md

### DIFF
--- a/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
+++ b/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
@@ -116,7 +116,7 @@ When the tool finishes running, it produces an output file in comma-separated (.
 - Supported Mailbox - If they are on an OAuth-enabled mailbox
 
 > [!NOTE]
-> Multifactor authentication is not supported when using the Central Deployment PowerShell module. The module only works with basic authentication.
+> Multifactor authentication is not supported when using the Central Deployment PowerShell module. The module only works with Basic authentication.
   
 ## User and group assignments
 

--- a/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
+++ b/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
@@ -116,7 +116,7 @@ When the tool finishes running, it produces an output file in comma-separated (.
 - Supported Mailbox - If they are on an OAuth-enabled mailbox
 
 > [!NOTE]
-> Multifactor authentication is not supported when using the Central Deployment PowerShell module.
+> Multifactor authentication is not supported when using the Central Deployment PowerShell module. The module only works with basic authentication.
   
 ## User and group assignments
 


### PR DESCRIPTION
Added a line stating that the module works only with Basic auth. As there is ambiguity on whether this works with Modern auth with MFA disabled.