### PR TITLE
Clarification of role groups in ExO & Compliance

### DIFF
--- a/microsoft-365/compliance/search-for-and-delete-messages-in-your-organization.md
+++ b/microsoft-365/compliance/search-for-and-delete-messages-in-your-organization.md
@@ -36,10 +36,10 @@ You can use the Content Search feature to search for and delete an email message
 
 ## Before you begin
 
-- To create and run a Content Search, you have to be a member of the **eDiscovery Manager** role group or be assigned the **Compliance Search** management role. To delete messages, you have to be a member of the **Organization Management** role group or be assigned the **Search And Purge** management role. For information about adding users to a role group, see [Assign eDiscovery permissions in the Security & Compliance Center](assign-ediscovery-permissions.md).
+- To create and run a Content search, you have to be a member of the **eDiscovery Manager** role group or be assigned the **Compliance Search** role in Security & Compliance Center. To delete messages, you have to be a member of the **Organization Management** role group or be assigned the **Search And Purge** role in Security & Compliance Center. For information about adding users to a role group, see [Assign eDiscovery permissions in the Security & Compliance Center](assign-ediscovery-permissions.md).
 
-> [!NOTE]
-> The **Organization Management** role group exists in both Exchange Online and Security & Compliance Center. These are separate role groups that give different permissions. Being a member of **Organization Management** in Exchange Online does not grant the required permissions to delete email messages. Failing to assign the permissions **Search And Purge** management role in Security & Compliance Center (either directly or through a role group such as **Organization Management**), you'll receive an error in Step 3 when you run the **New-ComplianceSearchAction** cmdlet with the message "A parameter cannot be found that matches parameter name 'Purge'".
+  > [!NOTE]
+  > The **Organization Management** role group exists in both Exchange Online and Security & Compliance Center. These are separate role groups that give different permissions. Being a member of **Organization Management** in Exchange Online does not grant the required permissions to delete email messages. If you aren't assigned the **Search And Purge** role in Security & Compliance Center (either directly or through a role group such as **Organization Management**), you'll receive an error in Step 3 when you run the **New-ComplianceSearchAction** cmdlet with the message "A parameter cannot be found that matches parameter name 'Purge'".
 
 - You have to use Security & Compliance Center PowerShell to delete messages. See [Step 2](#step-2-connect-to-security--compliance-center-powershell) for instructions about how to connect.
 

--- a/microsoft-365/compliance/search-for-and-delete-messages-in-your-organization.md
+++ b/microsoft-365/compliance/search-for-and-delete-messages-in-your-organization.md
@@ -38,6 +38,9 @@ You can use the Content Search feature to search for and delete an email message
 
 - To create and run a Content Search, you have to be a member of the **eDiscovery Manager** role group or be assigned the **Compliance Search** management role. To delete messages, you have to be a member of the **Organization Management** role group or be assigned the **Search And Purge** management role. For information about adding users to a role group, see [Assign eDiscovery permissions in the Security & Compliance Center](assign-ediscovery-permissions.md).
 
+> [!NOTE]
+> The **Organization Management** role group exists in both Exchange Online and Security & Compliance Center. These are separate role groups that give different permissions. Being a member of **Organization Management** in Exchange Online does not grant the required permissions to delete email messages. Failing to assign the permissions **Search And Purge** management role in Security & Compliance Center (either directly or through a role group such as **Organization Management**), you'll receive an error in Step 3 when you run the **New-ComplianceSearchAction** cmdlet with the message "A parameter cannot be found that matches parameter name 'Purge'".
+
 - You have to use Security & Compliance Center PowerShell to delete messages. See [Step 2](#step-2-connect-to-security--compliance-center-powershell) for instructions about how to connect.
 
 - A maximum of 10 items per mailbox can be removed at one time. Because the capability to search for and remove messages is intended to be an incident-response tool, this limit helps ensure that messages are quickly removed from mailboxes. This feature isn't intended to clean up user mailboxes.


### PR DESCRIPTION
Role groups in Exchange Online and Microsoft Compliance are different. Membership in Exchange Online's Organization Management does not give permissions to perform a purge. 

I feel like this is not made clear in the current wording, and can be confusing to Exchange Administrators (including myself) encountering this how-to guide, thinking that they should have the appropriate permissions by already being a member of Organization Management in Exchange Online.

If one is only assigned Organization Management in Exchange Online rather than through Compliance, when importing the PowerShell cmdlets you will not be getting access to the -Purge parameter in New-ComplianceSearchAction, and it will instead throw an error.