### PR TITLE
Update SCL setting name

### DIFF
--- a/microsoft-365/security/office-365-security/user-submission.md
+++ b/microsoft-365/security/office-365-security/user-submission.md
@@ -50,7 +50,7 @@ Delivering user reported messages to a custom mailbox instead of directly to Mic
 
 Use the following articles to configure the prerequisites required so user reported messages go to your custom mailbox:
 
-- Skip spam filtering on the custom mailbox by creating an exchange mail flow rule to set the spam confidence level. See [Use the EAC to create a mail flow rule that sets the SCL of a message](use-mail-flow-rules-to-set-the-spam-confidence-level-scl-in-messages.md#use-the-eac-to-create-a-mail-flow-rule-that-sets-the-scl-of-a-message) to set the SCL to **-1**.
+- Skip spam filtering on the custom mailbox by creating an exchange mail flow rule to set the spam confidence level. See [Use the EAC to create a mail flow rule that sets the SCL of a message](use-mail-flow-rules-to-set-the-spam-confidence-level-scl-in-messages.md#use-the-eac-to-create-a-mail-flow-rule-that-sets-the-scl-of-a-message) to set the SCL to **Bypass spam filtering**.
 
 - Turn off scanning attachments for malware in the custom mailbox. Use [Set up Safe Attachments policies in Defender for Office 365](set-up-safe-attachments-policies.md) to create a Safe Attachments policy with the setting **Off** for **Safe Attachments unknown malware response**.
 


### PR DESCRIPTION
The -1 setting was renamed to Bypass spam filtering. This change improves consistency with https://github.com/MicrosoftDocs/microsoft-365-docs/commit/10a7f0a6e876c6f8459a55ccf01ade99398dc71b