### PR TITLE
Removing Skype / Teams duplicate commands

### DIFF
--- a/microsoft-365/enterprise/connect-to-all-microsoft-365-services-in-a-single-windows-powershell-window.md
+++ b/microsoft-365/enterprise/connect-to-all-microsoft-365-services-in-a-single-windows-powershell-window.md
@@ -124,7 +124,7 @@ Follow these steps to connect to all the services in a single PowerShell window 
    > [!Note]
    > To connect to the Security &amp; Compliance Center for Microsoft 365 clouds other than Worldwide, see [Connect to Security & Compliance Center PowerShell](/powershell/exchange/connect-to-scc-powershell).
 
-7. Run these commands to connect to Teams PowerShell (and Skype for Business Online)
+7. Run these commands to connect to Teams PowerShell (and Skype for Business Online).
     
    ```powershell
    Import-Module MicrosoftTeams

--- a/microsoft-365/enterprise/connect-to-all-microsoft-365-services-in-a-single-windows-powershell-window.md
+++ b/microsoft-365/enterprise/connect-to-all-microsoft-365-services-in-a-single-windows-powershell-window.md
@@ -104,18 +104,7 @@ Follow these steps to connect to all the services in a single PowerShell window 
    Connect-SPOService -Url https://$orgName-admin.sharepoint.com -Credential $Credential
    ```
 
-5. Run these commands to connect to Skype for Business Online. A warning about increasing the `WSMan NetworkDelayms` value will appear the first time that you connect. Ignore it.
-     
-   > [!Note]
-   > Skype for Business Online Connector is currently part of the latest Teams PowerShell module. If you're using the latest Teams PowerShell public release, you don't need to install the Skype for Business Online Connector.
-   
-   ```powershell
-   Import-Module MicrosoftTeams
-   $credential = Get-Credential
-   Connect-MicrosoftTeams -Credential $credential
-   ```
-
-6. Run these commands to connect to Exchange Online.
+5. Run these commands to connect to Exchange Online.
     
    ```powershell
    Import-Module ExchangeOnlineManagement
@@ -125,7 +114,7 @@ Follow these steps to connect to all the services in a single PowerShell window 
    > [!Note]
    > To connect to Exchange Online for Microsoft 365 clouds other than Worldwide, see [Connect to Exchange Online PowerShell](/powershell/exchange/connect-to-exchange-online-powershell).
 
-7. Run these commands to connect to the Security &amp; Compliance Center.
+6. Run these commands to connect to the Security &amp; Compliance Center.
     
    ```powershell
    $acctName="<UPN of the account, such as belindan@litwareinc.onmicrosoft.com>"
@@ -135,7 +124,7 @@ Follow these steps to connect to all the services in a single PowerShell window 
    > [!Note]
    > To connect to the Security &amp; Compliance Center for Microsoft 365 clouds other than Worldwide, see [Connect to Security & Compliance Center PowerShell](/powershell/exchange/connect-to-scc-powershell).
 
-8. Run these commands to connect to Teams PowerShell.
+7. Run these commands to connect to Teams PowerShell (and Skype for Business Online)
     
    ```powershell
    Import-Module MicrosoftTeams
@@ -144,9 +133,11 @@ Follow these steps to connect to all the services in a single PowerShell window 
    ```
   
    > [!Note]
+   > Skype for Business Online Connector is currently part of the latest Teams PowerShell module. If you're using the latest Teams PowerShell public release, you don't need to install the Skype for Business Online Connector.
+  
+   > [!Note]
    > To connect to Microsoft Teams clouds other than *Worldwide*, see [Connect-MicrosoftTeams](/powershell/module/teams/connect-microsoftteams).
   
-
 
 
 ### Azure Active Directory PowerShell for Graph module
@@ -162,15 +153,12 @@ Connect-AzureAD -Credential $credential
 #SharePoint Online
 Import-Module Microsoft.Online.SharePoint.PowerShell -DisableNameChecking
 Connect-SPOService -Url https://$orgName-admin.sharepoint.com -credential $credential
-#Skype for Business Online
-Import-Module MicrosoftTeams
-Connect-MicrosoftTeams -Credential $credential
 #Exchange Online
 Import-Module ExchangeOnlineManagement
 Connect-ExchangeOnline -ShowProgress $true
 #Security & Compliance Center
 Connect-IPPSSession -UserPrincipalName $acctName
-#Teams
+#Teams and Skype for Business Online
 Import-Module MicrosoftTeams
 Connect-MicrosoftTeams -Credential $credential
 ```
@@ -188,15 +176,12 @@ Connect-MsolService -Credential $credential
 #SharePoint Online
 Import-Module Microsoft.Online.SharePoint.PowerShell -DisableNameChecking
 Connect-SPOService -Url https://$orgName-admin.sharepoint.com -credential $credential
-#Skype for Business Online
-Import-Module MicrosoftTeams
-Connect-MicrosoftTeams -Credential $credential
 #Exchange Online
 Import-Module ExchangeOnlineManagement
 Connect-ExchangeOnline -ShowProgress $true
 #Security & Compliance Center
 Connect-IPPSSession -UserPrincipalName $acctName
-#Teams
+#Teams and Skype for Business Online
 Import-Module MicrosoftTeams
 Connect-MicrosoftTeams -Credential $credential
 ```
@@ -214,15 +199,12 @@ $orgName="<for example, litwareinc for litwareinc.onmicrosoft.com>"
 Connect-AzureAD
 #SharePoint Online
 Connect-SPOService -Url https://$orgName-admin.sharepoint.com
-#Skype for Business Online
-Import-Module MicrosoftTeams
-Connect-MicrosoftTeams
 #Exchange Online
 Import-Module ExchangeOnlineManagement
 Connect-ExchangeOnline -UserPrincipalName $acctName -ShowProgress $true
 #Security & Compliance Center
 Connect-IPPSSession -UserPrincipalName $acctName
-#Teams
+#Teams and Skype for Business Online
 Import-Module MicrosoftTeams
 Connect-MicrosoftTeams
 ```
@@ -237,15 +219,12 @@ $orgName="<for example, litwareinc for litwareinc.onmicrosoft.com>"
 Connect-MsolService
 #SharePoint Online
 Connect-SPOService -Url https://$orgName-admin.sharepoint.com
-#Skype for Business Online
-Import-Module MicrosoftTeams
-Connect-MicrosoftTeams
 #Exchange Online
 Import-Module ExchangeOnlineManagement
 Connect-ExchangeOnline -UserPrincipalName $acctName -ShowProgress $true
 #Security & Compliance Center
 Connect-IPPSSession -UserPrincipalName $acctName
-#Teams
+#Teams and Skype for Business Online
 Import-Module MicrosoftTeams
 Connect-MicrosoftTeams
 ```


### PR DESCRIPTION
Skype for business online is now managed using Teams PowerShell. The article is duplicating the same command for both of them in the same PowerShell session which is confusing to the reader and is unnecessary when executing.