### PR TITLE
Update data-loss-prevention-policies.md

### DIFF
--- a/microsoft-365/compliance/data-loss-prevention-policies.md
+++ b/microsoft-365/compliance/data-loss-prevention-policies.md
@@ -540,7 +540,7 @@ When you create a DLP policy that includes Microsoft Teams as a location, the po
  
 ## Permissions
 
-Members of your compliance team who will create DLP policies need permissions to the Security &amp; Compliance Center. By default, your tenant admin will have access to this location and can give compliance officers and other people access to the Security &amp; Compliance Center, without giving them all of the permissions of a tenant admin. To do this, we recommend that you:
+By default, Global admin, Security admin and Complaince admin will have access to create and apply a DLP policy. Other Members of your compliance team who will create DLP policies need permissions to the Security &amp; Compliance Center. By default, your tenant admin will have access to this location and can give compliance officers and other people access to the Security &amp; Compliance Center, without giving them all of the permissions of a tenant admin. To do this, we recommend that you:
   
 1. Create a group in Microsoft 365 and add compliance officers to it.
     

--- a/microsoft-365/compliance/data-loss-prevention-policies.md
+++ b/microsoft-365/compliance/data-loss-prevention-policies.md
@@ -540,7 +540,7 @@ When you create a DLP policy that includes Microsoft Teams as a location, the po
  
 ## Permissions
 
-By default, Global admin, Security admin and Complaince admin will have access to create and apply a DLP policy. Other Members of your compliance team who will create DLP policies need permissions to the Security &amp; Compliance Center. By default, your tenant admin will have access to this location and can give compliance officers and other people access to the Security &amp; Compliance Center, without giving them all of the permissions of a tenant admin. To do this, we recommend that you:
+By default, Global admins, Security admins, and Compliance admins will have access to create and apply a DLP policy. Other Members of your compliance team who will create DLP policies need permissions to the Security &amp; Compliance Center. By default, your Tenant admin will have access to this location and can give compliance officers and other people access to the Security &amp; Compliance Center, without giving them all of the permissions of a Tenant admin. To do this, we recommend that you:
   
 1. Create a group in Microsoft 365 and add compliance officers to it.
     


### PR DESCRIPTION
Added a line stating that Compliance and security admin need no extra permissions to create or modify a policy as they have the access by default.