### PR TITLE
Changing example script update channel

### DIFF
--- a/microsoft-365/security/defender-endpoint/mac-updates.md
+++ b/microsoft-365/security/defender-endpoint/mac-updates.md
@@ -150,10 +150,17 @@ Set to false to send minimal heartbeat data, no application usage, and no enviro
 ## Example configuration profile
 
 The following configuration profile is used to:
-- Place the device in the Beta channel
+- Place the device in the Production channel
 - Automatically download and install updates
 - Enable the "Check for updates" button in the user interface
 - Allow users on the device to enroll into the Insider channels
+
+
+>[!WARNING]
+>The below configuration is an example configuration and should not be used in production without proper review of settings and tailor of configurations.
+
+>[!TIP]
+>In order to preview new features and provide early feedback, it is recommended that you configure some devices in your enterprise to `Beta` or `Preview`.
 
 ### JAMF
 
@@ -163,7 +170,7 @@ The following configuration profile is used to:
 <plist version="1.0">
 <dict>
 	<key>ChannelName</key>
-	<string>Beta</string>
+	<string>Production</string>
 	<key>HowToCheck</key>
 	<string>AutomaticDownload</string>
 	<key>EnableCheckForUpdatesButton</key>
@@ -223,7 +230,7 @@ The following configuration profile is used to:
             <key>PayloadEnabled</key>
             <true/>
             <key>ChannelName</key>
-            <string>Beta</string>
+            <string>Production</string>
             <key>HowToCheck</key>
             <string>AutomaticDownload</string>
             <key>EnableCheckForUpdatesButton</key>


### PR DESCRIPTION
This has been generating a lot of grief with customers and even field, because people is using these examples as their production XMLs, simply put because they often (and unfortunately) don't take the time to read the info in the page or reviewing the policies.