### PR TITLE
Update zero-hour-atuo-purge.md for the mailboxes on hold section

### DIFF
--- a/microsoft-365/security/office-365-security/zero-hour-auto-purge.md
+++ b/microsoft-365/security/office-365-security/zero-hour-auto-purge.md
@@ -115,6 +115,6 @@ ZAP still works as long as the message has not been deleted, or as long as the s
 
 ### How does ZAP affect mailboxes on hold?
 
-ZAP won't quarantine messages from mailboxes on hold. ZAP can move messages to the Junk Email folder based on the action that's configured for a spam or phishing verdict in anti-spam policies.
+ZAP will quarantine messages from mailboxes on hold. ZAP can move messages to the Junk Email folder based on the action that's configured for a spam or phishing verdict in anti-spam policies.
 
 For more information about holds in Exchange Online, see [In-Place Hold and Litigation Hold in Exchange Online](/Exchange/security-and-compliance/in-place-and-litigation-holds).


### PR DESCRIPTION
Customers were confused with the ZAP action for mailboxes on hold as the docs and the actual ZAP action differed. Currently, we do move messages to quarantine for mailboxes on hold. Updating the docs until we determine the intended functionality.