### PR TITLE
MCD migration - link correction, fixed wrong phase description

### DIFF
--- a/microsoft-365/enterprise/ms-cloud-germany-transition-add-pre-work.md
+++ b/microsoft-365/enterprise/ms-cloud-germany-transition-add-pre-work.md
@@ -94,16 +94,12 @@ The OCCT can be deployed on Windows clients at any time before phase 9. If the O
 
 ## Active Directory Federation Services (AD FS)
 
-<!-- before phase 4 -->
-
 **Applies to**: Customers using AD FS on premises to authenticate users connecting to Microsoft Office 365<br>
-**When applied**: Any time before phase 4 starts
+**When applied**: Any time before phase 2 starts
 
 Read and apply the [ADFS Migration steps](ms-cloud-germany-transition-add-adfs.md)
 
 ## SharePoint Online
-
-<!-- before phase 4 -->
 
 **Applies to**: Customers using SharePoint 2013 on-premises<br>
 **When applied**: Any time before phase 4 starts

--- a/microsoft-365/enterprise/ms-cloud-germany-transition-phases.md
+++ b/microsoft-365/enterprise/ms-cloud-germany-transition-phases.md
@@ -73,7 +73,7 @@ In case you are using single sign on for Office 365 and Azure in the Microsoft C
 
 **When applied**: Before phase 2 starts
 
-If you are using Active Directory Federation Services (AD FS), make sure to [back up your ADFS configuration before and after adding the relying party trust](ms-cloud-germany-transition-azure-ad.md) for the Office 365 Global service **before** the beginning of phase 2.
+If you are using Active Directory Federation Services (AD FS), make sure to [back up your ADFS configuration before and after adding the relying party trust](ms-cloud-germany-transition-add-adfs.md) for the Office 365 Global service **before** the beginning of phase 2.
 
 ## Phase 2: Azure AD Migration
 In this phase the Azure Active Directory will be migrated to the new datacenter region and become active. The old Azure AD endpoints will be still available.


### PR DESCRIPTION
corrected "applies to" information for AD FS step, fixed a link pointing to a wrong page.