### PR TITLE
Support Call Step 2 No Longer Required

### DIFF
--- a/microsoft-365/compliance/set-up-compliance-boundaries.md
+++ b/microsoft-365/compliance/set-up-compliance-boundaries.md
@@ -89,7 +89,7 @@ Although more user attributes are available, particularly for Exchange mailboxes
 ## Step 2: File a request with Microsoft Support to synchronize the user attribute to OneDrive accounts
 
 > [!IMPORTANT]
-> This step is no longer required as mailbox filters will apply to OneDrive for Business from the end of June 2021 and so raising the below support request will result in it being declined as it is no longer required.
+> This step is no longer required. Starting in June 2021, mailbox filters will apply to OneDrive for Business. Support requests to synchronize the attribute to OneDrive will be declined because it's no longer required. This article will be updated in the near future.
 
 The next step is to file a request with Microsoft Support to synchronize the Azure AD attribute that you chose in Step 1 to all OneDrive accounts in your organization. After this synchronization occurs, the attribute (and its value) that you chose in Step 1 will be mapped to a hidden managed property named `ComplianceAttribute`. You use this attribute to create the search permissions filter for OneDrive in Step 4.
   

--- a/microsoft-365/compliance/set-up-compliance-boundaries.md
+++ b/microsoft-365/compliance/set-up-compliance-boundaries.md
@@ -88,6 +88,9 @@ Although more user attributes are available, particularly for Exchange mailboxes
   
 ## Step 2: File a request with Microsoft Support to synchronize the user attribute to OneDrive accounts
 
+> [!IMPORTANT]
+> This step is no longer required as mailbox filters will apply to OneDrive for Business from the end of June 2021 and so raising the below support request will result in it being declined as it is no longer required.
+
 The next step is to file a request with Microsoft Support to synchronize the Azure AD attribute that you chose in Step 1 to all OneDrive accounts in your organization. After this synchronization occurs, the attribute (and its value) that you chose in Step 1 will be mapped to a hidden managed property named `ComplianceAttribute`. You use this attribute to create the search permissions filter for OneDrive in Step 4.
   
 Include the following information when you submit the request to Microsoft support:


### PR DESCRIPTION
I got this back from Microsoft Support today having raised this request as documented yesterday. Therefore this document is out of date and I am sure you have a new version planned as steps are not required, but for now this document should be updated to say it is not required to request step 2

Your request (26034738) has been updated
Good day!
As per our Engineering team, we are no longer accepting this type of requests.
This is because by the end of this month, mailbox filters will apply to OneDrive for Business so it is no longer necessary to raise a request.
Message Center reference code is MC256471.
Please do let me know if you need further assistance or if we can now proceed on closing this case.
Thanks and have a great day!
Kath