### PR TITLE
Update centralized-deployment-FAQ.md

### DIFF
--- a/microsoft-365/admin/manage/centralized-deployment-FAQ.md
+++ b/microsoft-365/admin/manage/centralized-deployment-FAQ.md
@@ -92,7 +92,7 @@ We suggest reaching out to the ISV Developer for the paid add-in to request a ma
     
 ## Which admin role do I need to manage add-ins for my organization?  
 
-Global Admin is the recommended role with complete access to add-in management lifecycle. Other Admin roles have a limited access to add-in deployment lifecycle. If you're the person who purchased your Microsoft 365 for business subscription, you are the Global admin. 
+Global Admin is the recommended role with complete access to add-in management lifecycle. If you're the person who purchased your Microsoft 365 for business subscription, you are the Global admin. 
  
 Your subscription comes with a set of admin roles that you can assign to other users in your organization. Each admin role maps to common business functions and gives people in your organization permissions to perform specific tasks in the Microsoft 365 admin center.  
  

--- a/microsoft-365/admin/manage/centralized-deployment-FAQ.md
+++ b/microsoft-365/admin/manage/centralized-deployment-FAQ.md
@@ -92,7 +92,7 @@ We suggest reaching out to the ISV Developer for the paid add-in to request a ma
     
 ## Which admin role do I need to manage add-ins for my organization?  
 
-Global Admin is the recommended role with complete access to add-in management lifecycle. If you're the person who purchased your Microsoft 365 for business subscription, you are the Global admin. 
+Global Admin is the recommended role with complete access to add-in management lifecycle. If you're the person who purchased your Microsoft 365 Business subscription, you are the Global admin. 
  
 Your subscription comes with a set of admin roles that you can assign to other users in your organization. Each admin role maps to common business functions and gives people in your organization permissions to perform specific tasks in the Microsoft 365 admin center.  
  


### PR DESCRIPTION
Global admin is the only role that can deploy the add-in.. Tested with the roles that had this access earlier (Exchange admin and Office apps admin), But both don't have the integrated apps option anymore.