### PR TITLE
Update configure-block-at-first-sight-microsoft-defender-antivirus.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
@@ -26,7 +26,7 @@ ms.topic: article
 This article describes an antivirus/antimalware feature known as "block at first sight", and describes how to enable block at first sight for your organization. 
 
 > [!TIP]
-> This article is intended for enterprise admins and IT Pros who manage security settings for organizations. If you are not an enteprise admin or IT Pro but you have questions about block at first sight, see [Not an enterprise admin or IT Pro?](#not-an-enterprise-admin-or-it-pro).
+> This article is intended for enterprise admins and IT Pros who manage security settings for organizations. If you are not an enteprise admin or IT Pro but you have questions about block at first sight, see the [Not an enterprise admin or IT Pro?](#not-an-enterprise-admin-or-it-pro) section.
 
 ## What is "block at first sight"?
 
@@ -47,7 +47,7 @@ Microsoft Defender Antivirus uses multiple detection and prevention technologies
 ![List of Microsoft Defender AV engines](images/microsoft-defender-atp-next-generation-protection-engines.png)  
 
 > [!TIP]
-> To learn more, see this blog: [Get to know the advanced technologies at the core of Microsoft Defender for Endpoint next-generation protection](https://www.microsoft.com/security/blog/2019/06/24/inside-out-get-to-know-the-advanced-technologies-at-the-core-of-microsoft-defender-atp-next-generation-protection/).
+> To learn more, see [(Blog) Get to know the advanced technologies at the core of Microsoft Defender for Endpoint next-generation protection](https://www.microsoft.com/security/blog/2019/06/24/inside-out-get-to-know-the-advanced-technologies-at-the-core-of-microsoft-defender-atp-next-generation-protection/).
 
 ## A few things to know about block at first sight
 
@@ -141,7 +141,7 @@ You can confirm that block at first sight is enabled on individual client device
 
 ## Validate block at first sight is working
 
-To validate that the feature is working, attempt to download the [Block at First Sight sample file](https://demo.wd.microsoft.com/Page/BAFS). To download the file, you will need an Azure AD credential from your organization and a Security Administrator or Global Administrator Azure AD role assigned to that account.
+To validate that the feature is working, download the [Block at First Sight sample file](https://demo.wd.microsoft.com/Page/BAFS). To download the file, you will need an account in Azure AD that has either the Security Administrator or Global Administrator role assigned.
 
 To validate that cloud-enabled protection is working, follow the guidance in [Validate connections between your network and the cloud](configure-network-connections-microsoft-defender-antivirus.md#validate-connections-between-your-network-and-the-cloud). 
 

--- a/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
@@ -141,7 +141,7 @@ You can confirm that block at first sight is enabled on individual client device
 
 ## Validate block at first sight is working
 
-To validate that the feature is working, attempt to download the Block at First Sight sample file from https://demo.wd.microsoft.com/Page/BAFS. To download the file, you will need an Azure AD credential from your organization and a Security Administrator or Global Administrator Azure AD role assigned to that account.
+To validate that the feature is working, attempt to download the [Block at First Sight sample file](https://demo.wd.microsoft.com/Page/BAFS). To download the file, you will need an Azure AD credential from your organization and a Security Administrator or Global Administrator Azure AD role assigned to that account.
 
 To validate that cloud-enabled protection is working, follow the guidance in [Validate connections between your network and the cloud](configure-network-connections-microsoft-defender-antivirus.md#validate-connections-between-your-network-and-the-cloud). 
 

--- a/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
@@ -12,15 +12,12 @@ ms.author: deniseb
 ms.reviewer: marcmcc
 manager: dansimp
 ms.custom: nextgen
-ms.date: 04/28/2021
+ms.date: 06/15/2021
 ms.technology: mde
 ms.topic: article
 ---
 
 # Turn on block at first sight
-
-[!INCLUDE [Microsoft 365 Defender rebranding](../../includes/microsoft-defender.md)]
-
 
 **Applies to:**
 

--- a/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
@@ -141,7 +141,7 @@ You can confirm that block at first sight is enabled on individual client device
 
 ## Validate block at first sight is working
 
-To validate that the feature is working, download the [Block at First Sight sample file](https://demo.wd.microsoft.com/Page/BAFS). To download the file, you will need an account in Azure AD that has either the Security Administrator or Global Administrator role assigned.
+To validate that the feature is working, download the [Block at first sight sample file](https://demo.wd.microsoft.com/Page/BAFS). To download the file, you will need an account in Azure AD that has either the Security Administrator or Global Administrator role assigned.
 
 To validate that cloud-enabled protection is working, follow the guidance in [Validate connections between your network and the cloud](configure-network-connections-microsoft-defender-antivirus.md#validate-connections-between-your-network-and-the-cloud). 
 

--- a/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-block-at-first-sight-microsoft-defender-antivirus.md
@@ -144,7 +144,9 @@ You can confirm that block at first sight is enabled on individual client device
 
 ## Validate block at first sight is working
 
-To validate that the feature is working, follow the guidance in [Validate connections between your network and the cloud](configure-network-connections-microsoft-defender-antivirus.md#validate-connections-between-your-network-and-the-cloud).
+To validate that the feature is working, attempt to download the Block at First Sight sample file from https://demo.wd.microsoft.com/Page/BAFS. To download the file, you will need an Azure AD credential from your organization and a Security Administrator or Global Administrator Azure AD role assigned to that account.
+
+To validate that cloud-enabled protection is working, follow the guidance in [Validate connections between your network and the cloud](configure-network-connections-microsoft-defender-antivirus.md#validate-connections-between-your-network-and-the-cloud). 
 
 ## Turn off block at first sight
 


### PR DESCRIPTION
The "Validate block at first sight is working" section was pointing to a document on how to validate Cloud protection is working but it was not specific to BaFS. I added a small paragraph that informs the reader to access the Defender Demos page to access the BaFS page.