### PR TITLE
Correction on entry point of spoof insight

### DIFF
--- a/microsoft-365/security/office-365-security/learn-about-spoof-intelligence.md
+++ b/microsoft-365/security/office-365-security/learn-about-spoof-intelligence.md
@@ -88,9 +88,9 @@ The rest of this article explains how to use the spoof intelligence insight in t
 
 ## Open the spoof intelligence insight in the Microsoft 365 Defender portal
 
-1. In the Microsoft 365 Defender portal, go to **Email & Collaboration** \> **Policies & Rules** \> **Threat policies** page \> **Policies** section \> **Anti-phishing**.
+1. In the Microsoft 365 Defender portal, go to **Email & Collaboration** \> **Policies & Rules** \> **Threat policies** page \> **Tenant Allow/Block Lists**.
 
-2. On the **Anti-phishing** page, the spoof intelligence insight looks like this:
+2. On the **Tenant Allow/Block Lists** page, the spoof intelligence insight looks like this:
 
    ![Spoof intelligence insight on the Anti-phishing policy page](../../media/m365-sc-spoof-intelligence-insight.png)
 


### PR DESCRIPTION
Spoof intelligence insight entry point (light bulb) tip is shown on Tenant Allow/Block Lists page not on Anti-Phishing policy page. Corrected the info.