### PR TITLE
Update set-password-to-never-expire.md

### DIFF
--- a/microsoft-365/admin/add-users/set-password-to-never-expire.md
+++ b/microsoft-365/admin/add-users/set-password-to-never-expire.md
@@ -37,8 +37,6 @@ A global admin for a Microsoft cloud service can use the [Azure Active Directory
 
 This guide applies to other providers, such as Intune and Microsoft 365, which also rely on Azure AD for identity and directory services. Password expiration is the only part of the policy that can be changed.
 
-> [!NOTE]
-> Only passwords for user accounts that are not synchronized through directory synchronization can be configured to not expire. For more information about directory synchronization, see [Connect AD with Azure AD](/azure/active-directory/connect/active-directory-aadconnect).
 
 ## How to check the expiration policy for a password
 


### PR DESCRIPTION
Removed the note about the cloud only accounts can have a password expiration policy as synchronized users can have password expiration policies setup on Azure

Reference:- https://dorcs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-password-hash-synchronization#enforcecloudpasswordpolicyforpasswordsyncedusers