### PR TITLE
Update configure-email-forwarding.md

### DIFF
--- a/microsoft-365/admin/email/configure-email-forwarding.md
+++ b/microsoft-365/admin/email/configure-email-forwarding.md
@@ -44,6 +44,8 @@ Before you set up email forwarding, note the following:
 
 You must be an Exchange administrator or Global administrator in Microsoft 365 to do these steps. For more information, see the topic [About admin roles](../add-users/about-admin-roles.md).
 
+::: moniker range="o365-worldwide"
+
 1. In the admin center, go to the **Users** \> **[Active users](https://go.microsoft.com/fwlink/p/?linkid=834822)** page.
 
 2. Select the name of the user whose email you want to forward, then open the properties page.


### PR DESCRIPTION
I don't know how to add the "moniker range" for o365-worldwide... but, if it is not added, in the view for WW we see "::: moniker-end" entry.
In the views for Germany or 21vianet we see the section for WW, but also the section for Germany / 21vianet, with a "::: moniker-end" entry between them.