### PR TITLE
Added missing directions on enabling LTIs

### DIFF
--- a/microsoft-365/lti/teams-meetings-with-canvas.md
+++ b/microsoft-365/lti/teams-meetings-with-canvas.md
@@ -74,3 +74,9 @@ As a Canvas Admin, you'll need to add the Microsoft Teams meetings LTI app withi
 5. Select **Install**.
 
    The Microsoft Teams meetings LTI app will be added to the list of external apps.
+   
+## Enable for Canvas Courses
+
+In order to use the LTI within a course, an instructor of the Canvas course must enable the integrations sync. Each course must be enabled by an instructor for a corresponding Teams to be created; there is no global mechanism for Teams creation. This is designed out of caution to prevent unwanted Teams being created.
+
+Please refer your instructors to [educator documentation](https://support.microsoft.com/en-us/topic/use-microsoft-teams-classes-in-your-lms-preview-ac6a1e34-32f7-45e6-b83e-094185a1e78a#ID0EBD=Instructure_Canvas) for enabling the LTI for each course and finishing the integration setup.


### PR DESCRIPTION
Explicitly reminding administrators that enabling the integration for each course is needed before the Teams gets created. Without this, customers were confused and ran into difficulty deploying.