### PR TITLE
By default, users get copies of meeting invitation

### DIFF
--- a/microsoft-365/admin/create-groups/manage-groups.md
+++ b/microsoft-365/admin/create-groups/manage-groups.md
@@ -49,7 +49,7 @@ Go to the Microsoft 365 admin center at [https://admin.microsoft.com](https://ad
 
 ## Send copies of conversations to group members' inboxes
   
-When you use the admin center to create a group, by default users  do not get copies of group emails and meeting invitations sent to their inboxes. They'll need to go to the group to see conversations and meetings. You can change this setting in the admin center.
+When you use the admin center to create a group, by default users do not get copies of group emails sent to their inboxes though users get copies of group meeting invitations sent to their inboxes. They'll need to go to the group to see conversations. You can change this setting in the admin center.
 
 When you turn this setting on, group members will get a copy of group emails and meeting invitations sent to their Outlook Inbox. They can read and delete this copy of the email and not affect anyone else. In the Group inbox, a copy of the email still exists.
 


### PR DESCRIPTION
When you create a group in admin center, the following value set to a group. So users do not get copies of group emails but users get copies of meeting invitations by default.

AutoSubscribeNewMembers                : False
AlwaysSubscribeMembersToCalendarEvents : True

If you check [Send copies of group conversations and events to group members] in admin center, AutoSubscribeNewMembers turns into true. So users get copies of emails and meeting invitations.
(FYI, if AlwaysSubscribeMembersToCalendarEvents is False, users get a copies of calendar events because AutoSubscribeNewMembers specifies conversations and calendar events.)