### PR TITLE
Update assign-licenses-to-user-accounts-with-microsoft-365-powershell.md

### DIFF
--- a/microsoft-365/enterprise/assign-licenses-to-user-accounts-with-microsoft-365-powershell.md
+++ b/microsoft-365/enterprise/assign-licenses-to-user-accounts-with-microsoft-365-powershell.md
@@ -188,10 +188,6 @@ $subscriptionTo="<SKU part number of the new subscription>"
 # Unassign
 $license = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicense
 $licenses = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicenses
-$license.SkuId = (Get-AzureADSubscribedSku | Where-Object -Property SkuPartNumber -Value $subscriptionFrom -EQ).SkuID
-$licenses.AddLicenses = $license
-Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
-$licenses.AddLicenses = @()
 $licenses.RemoveLicenses =  (Get-AzureADSubscribedSku | Where-Object -Property SkuPartNumber -Value $subscriptionFrom -EQ).SkuID
 Set-AzureADUserLicense -ObjectId $userUPN -AssignedLicenses $licenses
 # Assign


### PR DESCRIPTION
Remove assign license code from the un-assign section of the script so as to remove confusion.