### PR TITLE
M365D APIs are GA - not Preview

### DIFF
--- a/microsoft-365/security/defender/index.yml
+++ b/microsoft-365/security/defender/index.yml
@@ -129,5 +129,5 @@ landingContent:
     linkLists:
       - linkListType: reference
         links:
-          - text: Microsoft 365 Defender APIs (preview)
+          - text: Microsoft 365 Defender APIs
             url: api-overview.md


### PR DESCRIPTION
Remove "(Preview)" from M365 Defender APIs label and link (also removing from the target page)