### PR TITLE
Update restore-deleted-group.md

### DIFF
--- a/microsoft-365/admin/create-groups/restore-deleted-group.md
+++ b/microsoft-365/admin/create-groups/restore-deleted-group.md
@@ -46,7 +46,7 @@ When a group is restored, the following content is restored:
 
 - Yammer group and group content (If the Microsoft 365 group was created from Yammer)
 
-- Power BI Classic workspace (more info about Classic worpace can be found here https://docs.microsoft.com/en-us/power-bi/collaborate-share/service-create-workspaces)
+- Power BI [Classic workspace](/power-bi/collaborate-share/service-create-workspaces)
 
 > [!NOTE]
 > This article describes restoring only Microsoft 365 groups. All other groups cannot be restored once deleted.

--- a/microsoft-365/admin/create-groups/restore-deleted-group.md
+++ b/microsoft-365/admin/create-groups/restore-deleted-group.md
@@ -46,6 +46,8 @@ When a group is restored, the following content is restored:
 
 - Yammer group and group content (If the Microsoft 365 group was created from Yammer)
 
+- Power BI Classic workspace (more info about Classic worpace can be found here https://docs.microsoft.com/en-us/power-bi/collaborate-share/service-create-workspaces)
+
 > [!NOTE]
 > This article describes restoring only Microsoft 365 groups. All other groups cannot be restored once deleted.
 


### PR DESCRIPTION
once an O365 group is deleted, the Power BI classic workspace also gets deleted and it can be recovered in maximum 30 days (the same amount of time that an O365 groups stays in deleted stage)