### PR TITLE
Move note to top of article

### DIFF
--- a/microsoft-365/compliance/enable-autoexpanding-archiving.md
+++ b/microsoft-365/compliance/enable-autoexpanding-archiving.md
@@ -31,6 +31,8 @@ You can use the Exchange Online auto-expanding archiving feature to enable addit
 
 - A user's archive mailbox has to be enabled before you can enable auto-expanding archiving. A user must be assigned an Exchange Online Plan 2 license to enable the archive mailbox. If a user is assigned an Exchange Online Plan 1 license, you would have to assign them a separate Exchange Online Archiving license to enable their archive mailbox. See [Enable archive mailboxes](enable-archive-mailboxes.md).
 
+ After you turn on auto-expanding archiving for your organization or for a specific user, an archive mailbox is converted to an auto-expanding archive when the archive mailbox (including the Recoverable Items folder) reaches 90 GB. It can take up to 30 days for the additional storage space to be provisioned.
+ 
 - You can also use PowerShell to enable archive mailboxes. See the [More information](#more-information) section for an example of the PowerShell command that you can use to enable archive mailboxes for all users in your organization.
 
 - Auto-expanding archiving also supports shared mailboxes. To enable the archive for a shared mailbox, an Exchange Online Plan 2 license or an Exchange Online Plan 1 license with an Exchange Online Archiving license is required.
@@ -116,7 +118,6 @@ Keep the following things in mind after you enable auto-expanding archiving:
     Get-Mailbox -Filter {ArchiveStatus -Eq "None" -AND RecipientTypeDetails -eq "UserMailbox"} | Enable-Mailbox -Archive
     ```
 
-- After you turn on auto-expanding archiving for your organization or for a specific user, an archive mailbox is converted to an auto-expanding archive when the archive mailbox (including the Recoverable Items folder) reaches 90 GB. It can take up to 30 days for the additional storage space to be provisioned.
 
 - After you turn on auto-expanding archiving, it can't be turned off. Additionally, administrators can't adjust the storage quota for auto-expanding archiving.
 


### PR DESCRIPTION
@markjjo   Can we move the following note to the top of the article, we are getting escalations to disable this after customers have enabled this for their users and org.  I think if we move the comment up on the article, it would help.

"After you turn on auto-expanding archiving, it can't be turned off. Additionally, administrators can't adjust the storage quota for auto-expanding archiving"