### PR TITLE
Update approval comments value to accept null with ?

### DIFF
--- a/microsoft-365/contentunderstanding/solution-manage-contracts-step3.md
+++ b/microsoft-365/contentunderstanding/solution-manage-contracts-step3.md
@@ -155,7 +155,7 @@ When a contract has been approved, the following things occur:
     | Approval state  | body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['submitActionId']         |
     | Approved by     | body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['responder']['displayName']        |
     | Approval date     | body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['responseTime']         |
-    | Comment     | body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']['acComments']         |
+    | Comment     | body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']?['acComments']         |
     
     The following example shows how to use the formula box in Power Automate to write an expression.
 
@@ -227,7 +227,7 @@ When a contract has been approved, the following things occur:
                         },
                         {
                             "title": "Approval comment",
-                            "value": "@{body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']['acComments']}"
+                            "value": "@{body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']?['acComments']}"
                         },
                         {
                             "title": " ",
@@ -323,7 +323,7 @@ The following code is the JSON used for this step in the Power Automate flow.
                         },
                         {
                             "title": "Comment",
-                            "value": "@{body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']['acComments']}"
+                            "value": "@{body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']?['acComments']}"
                         },
                         {
                             "title": " ",


### PR DESCRIPTION
Flow was failing if a user did not attend a comment in the approval

so I changed to allow nulls
body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']['acComments']
to
body('Post_an_Adaptive_Card_to_a_Teams_channel_and_wait_for_a_response')?['data']?['acComments']

It now works if a user enters a comment or does not