### PR TITLE
Tagging example was wrong

### DIFF
--- a/microsoft-365/security/defender-endpoint/linux-preferences.md
+++ b/microsoft-365/security/defender-endpoint/linux-preferences.md
@@ -607,7 +607,7 @@ When you run the `mdatp health` command for the first time, the value for the ta
   ```
 
   > [!NOTE]
-  > Don’t forget to add the comma after the closing curly bracket at the end of the `cloudService` block. Also, make sure that there are two closing curly brackets after adding Tag or Group ID block (please see the above example). Please note that the only supported key name for tags is GROUP at the moment.
+  > Don’t forget to add the comma after the closing curly bracket at the end of the `cloudService` block. Also, make sure that there are two closing curly brackets after adding Tag or Group ID block (please see the above example). At the moment, the only supported key name for tags is `GROUP`. 
   
 ## Configuration profile validation
 

--- a/microsoft-365/security/defender-endpoint/linux-preferences.md
+++ b/microsoft-365/security/defender-endpoint/linux-preferences.md
@@ -587,22 +587,27 @@ When you run the `mdatp health` command for the first time, the value for the ta
 
   ```JSON
     },
-     "cloudService":{
-        "enabled":true,
-        "diagnosticLevel":"optional",
-        "automaticSampleSubmissionConsent":"safe",
-        "automaticDefinitionUpdateEnabled":true,
-        "proxy": "http://proxy.server:port/"
-     },
-     "edr":{
-          "groupIds":"GroupIdExample",
-          "tags":"MDETagExample"
-          }
+    "cloudService": {
+      "enabled": true,
+      "diagnosticLevel": "optional",
+      "automaticSampleSubmissionConsent": "safe",
+      "automaticDefinitionUpdateEnabled": true,
+      "proxy": "http://proxy.server:port/"
+  },
+  "edr": {
+    "groupIds":"GroupIdExample",
+    "tags": [
+              {
+              "key": "GROUP",
+              "value": "Tag"
+              }
+            ]
+        }
   }
   ```
 
   > [!NOTE]
-  > Don’t forget to add the comma after the closing curly bracket at the end of the `cloudService` block. Also, make sure that there are two closing curly brackets after adding Tag or Group ID block (please see the above example).
+  > Don’t forget to add the comma after the closing curly bracket at the end of the `cloudService` block. Also, make sure that there are two closing curly brackets after adding Tag or Group ID block (please see the above example). Please note that the only supported key name for tags is GROUP at the moment.
   
 ## Configuration profile validation
 


### PR DESCRIPTION
The provided tagging example was wrong. I updated it with a working example. I also pointed out that the key name must be GROUP.