### PR TITLE
Update centralized-deployment-of-add-ins.md

### DIFF
--- a/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
+++ b/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
@@ -83,7 +83,7 @@ Check with your organization's Exchange admin to find out which configuration is
 In order to deploy an add-in via Centralized Deployement, you need to be either a Global admin or an Exchange admin in the organization.
 
 > [!NOTE]
-> An Exchange admin can deploy an add-in only if the **App Registrations** property is set to true in Azure Active Directory admin center as shown in the following image:
+> An Exchange admin can deploy an add-in If the **Application Administatrator** role is added or if the **App Registrations** property is set to true in Azure Active Directory admin center as shown in the following image:
 >
 > ![image](https://user-images.githubusercontent.com/89943918/144516704-8874a10d-b540-41f3-ae9d-c07a8d7e143f.png)
 

--- a/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
+++ b/microsoft-365/admin/manage/centralized-deployment-of-add-ins.md
@@ -83,7 +83,7 @@ Check with your organization's Exchange admin to find out which configuration is
 In order to deploy an add-in via Centralized Deployement, you need to be either a Global admin or an Exchange admin in the organization.
 
 > [!NOTE]
-> An Exchange admin can deploy an add-in If the **Application Administatrator** role is added or if the **App Registrations** property is set to true in Azure Active Directory admin center as shown in the following image:
+> An Exchange admin can deploy an add-in if the **Application Administrator** role is added or if the **App Registrations** property is set to true in Azure Active Directory admin center as shown in the following image:
 >
 > ![image](https://user-images.githubusercontent.com/89943918/144516704-8874a10d-b540-41f3-ae9d-c07a8d7e143f.png)
 


### PR DESCRIPTION
Exchange admin + Application admin role helps to deploy add-in via centralized deployment, even if user enablement is disabled.