### PR TITLE
Update remove-former-employee-step-6.md

### DIFF
--- a/microsoft-365/admin/add-users/remove-former-employee-step-6.md
+++ b/microsoft-365/admin/add-users/remove-former-employee-step-6.md
@@ -30,6 +30,8 @@ description: "Follow these steps to remove the Microsoft 365 license from a form
 # Step 6 - Remove the Microsoft 365 license from a former employee
 
 If you don't want to pay for a license after someone leaves your organization, you need to remove their Microsoft 365 license and then delete it from your subscription. You can assign a license to another user if you don't delete it.
+
+If the mailbox needs to be accessed by authorized people who have been granted eDiscovery permissions for compliance or legal reasons, it must be assigned an Exchange Online Plan 2 license (or an Exchange Online Plan 1 license with an Exchange Online Archiving add-on license) so that a hold can be applied to the mailbox before it's deleted. After the user account is deleted, any Exchange Online license associated with the user account will be available to assign to a new user.
   
 When you remove the license, all that user's data is held for 30 days. You can [access](get-access-to-and-back-up-a-former-user-s-data.md) the data, or [restore](restore-user.md) the account if the user comes back. After 30 days, all the user's data (except for documents stored on SharePoint Online) is permanently deleted from Microsoft 365 and can't be recovered.
 


### PR DESCRIPTION
Added a statement stating the license should not be removed before deleting if they would like to use the mailbox for compliance or legal reasons.