### PR TITLE
Update printer-protection.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/printer-protection.md
+++ b/microsoft-365/security/defender-endpoint/printer-protection.md
@@ -101,7 +101,7 @@ The CSP support string with `<enabled/>`:
 
   `./Vendor/MSFT/Policy/Config/Printers/ApprovedUsbPrintDevicesUser`
 
-The CSP support string with approved USB printers via 'ApprovedUsbPrintDevices' property, example `<enabled><data id="ApprovedUsbPrintDevices_List" value="03F0/0853,0351/0872">`:
+The CSP support string with approved USB printers via 'ApprovedUsbPrintDevices' property, example `<enabled><data id="ApprovedUsbPrintDevices_List" value="03F0/0853,0351/0872"/>`:
 
 :::image type="content" source="../../media/editrow.png" alt-text="edit row.":::
 


### PR DESCRIPTION
Updating Update printer-protection.md with the correct policy value for the 'AppovedUsbPrintDevices_List". The original was missing "/" and therefore causing an error when customers tried to follow the example.