### PR TITLE
Note that Mail Contacts are not supported

### DIFF
--- a/microsoft-365/compliance/encryption-sensitivity-labels.md
+++ b/microsoft-365/compliance/encryption-sensitivity-labels.md
@@ -190,6 +190,9 @@ When you assign permissions, you can choose:
 
 - Any specific user or email-enabled security group, distribution group, or Microsoft 365 group ([formerly Office 365 group](https://techcommunity.microsoft.com/t5/microsoft-365-blog/office-365-groups-will-become-microsoft-365-groups/ba-p/1303601)) in Azure AD. The Microsoft 365 group can have static or [dynamic membership](/azure/active-directory/users-groups-roles/groups-create-rule). Note that you can't use a [dynamic distribution group from Exchange](/Exchange/recipients/dynamic-distribution-groups/dynamic-distribution-groups) because this group type isn't synchronized to Azure AD, and you can't use a security group that isn't email-enabled.
 
+    > [!NOTE]
+    > Exchange Online Mail Contacts in groups are not supported. Objects must be of type user.
+
 - Any email address or domain. Use this option to specify all users in another organization who uses Azure AD, by entering any domain name from that organization. You can also use this option for social providers, by entering their domain name such as **gmail.com**, **hotmail.com**, or **outlook.com**.
 
     > [!NOTE]


### PR DESCRIPTION
Support case 27241509 describes that mail contacts are not supported in groups:
 "Regarding the groups yes you can use them but the users inside them cannot be of type Contact, they must be of type User."