### PR TITLE
Merged two lists of blockers for protected documents on the web

### DIFF
--- a/microsoft-365/compliance/sensitivity-labels-sharepoint-onedrive-files.md
+++ b/microsoft-365/compliance/sensitivity-labels-sharepoint-onedrive-files.md
@@ -82,7 +82,7 @@ Use the OneDrive sync app version 19.002.0121.0008 or later on Windows, and vers
   - **User access to content expires** is set to a value other than **Never**.
   - **Double Key Encryption** is selected.
   - Encryption that was applied **independently from a label**, for example, by directly applying a Rights Management protection template.
-  - Encryption that uses an on-premises key ("**hold your own key**" or HYOK)
+  - Encryption that uses an on-premises key ("**hold your own key**" or HYOK).
 
     For labels with any of these encryption configurations, the labels aren't displayed to users in Office for the web. Additionally, the new capabilities can't be used with labeled documents that already have these encryption settings. For example, these documents won't be returned in search results, even if they are updated. Documents that have been encrypted in one of these ways can't be opened in Office for the web.
 

--- a/microsoft-365/compliance/sensitivity-labels-sharepoint-onedrive-files.md
+++ b/microsoft-365/compliance/sensitivity-labels-sharepoint-onedrive-files.md
@@ -81,8 +81,10 @@ Use the OneDrive sync app version 19.002.0121.0008 or later on Windows, and vers
   - **Let users assign permissions when they apply the label** and the checkbox **In Word, PowerPoint, and Excel, prompt users to specify permissions** is selected. This setting is sometimes referred to as "user-defined permissions".
   - **User access to content expires** is set to a value other than **Never**.
   - **Double Key Encryption** is selected.
+  - Encryption that was applied **independently from a label**, for example, by directly applying a Rights Management protection template.
+  - Encryption that uses an on-premises key ("**hold your own key**" or HYOK)
 
-    For labels with any of these encryption configurations, the labels aren't displayed to users in Office for the web. Additionally, the new capabilities can't be used with labeled documents that already have these encryption settings. For example, these documents won't be returned in search results, even if they are updated.
+    For labels with any of these encryption configurations, the labels aren't displayed to users in Office for the web. Additionally, the new capabilities can't be used with labeled documents that already have these encryption settings. For example, these documents won't be returned in search results, even if they are updated. Documents that have been encrypted in one of these ways can't be opened in Office for the web.
 
 - For performance reasons, when you upload or save a document to SharePoint and the file's label doesn't apply encryption, the **Sensitivity** column in the document library can take a while to display the label name. Factor in this delay if you use scripts or automation that depend on the label name in this column.
 
@@ -106,11 +108,6 @@ Use the OneDrive sync app version 19.002.0121.0008 or later on Windows, and vers
 - If an admin changes settings for a published label that's already applied to files downloaded to users' sync client, users might be unable to save changes they make to the file in their OneDrive Sync folder. This scenario applies to files that are labeled with encryption, and also when the label change is from a label that didn't apply encryption to a label that does apply encryption. Users see a [red circle with a white cross icon error](https://support.office.com/article/what-do-the-onedrive-icons-mean-11143026-8000-44f8-aaa9-67c985aa49b3), and they are asked to save new changes as a separate copy. Instead, they can close and reopen the file, or use Office for the web.
 
 - Users can experience save problems after going offline or into a sleep mode when instead of using Office for the web, they use the desktop and mobile apps for Word, Excel, or PowerPoint. For these users, when they resume their Office app session and try to save changes, they see an upload failure message with an option to save a copy instead of saving the original file.
-
-- Documents that have been encrypted in the following ways can't be opened in Office for the web:
-  - Encryption that uses an on-premises key ("hold your own key" or HYOK)
-  - Encryption that was applied by using [Double Key Encryption](double-key-encryption.md)
-  - Encryption that was applied independently from a label, for example, by directly applying a Rights Management protection template.
 
 - Labels configured for [other languages](create-sensitivity-labels.md#additional-label-settings-with-security--compliance-center-powershell) are not supported and display the original language only.
 


### PR DESCRIPTION
There were two separate lists of label properties that both result in SPO not being able to process a file and office on the we not being able to open that documents. I merged the two, because the underlying cause is the same.

The only item I have not tested myself is the "User access to content expires".

And user-defined permissions is about to come in June: https://www.microsoft.com/en-us/microsoft-365/roadmap?filters=&searchterms=85619