### PR TITLE
Update configure-exchange-server-for-hybrid-modern-authentication.md

### DIFF
--- a/microsoft-365/enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
+++ b/microsoft-365/enterprise/configure-exchange-server-for-hybrid-modern-authentication.md
@@ -73,7 +73,7 @@ First, gather all the URLs that you need to add in AAD. Run these commands on-pr
 ```powershell
 Get-MapiVirtualDirectory | FL server,*url*
 Get-WebServicesVirtualDirectory | FL server,*url*
-Get-ClientAccessServer | fl Name, AutodiscoverServiceInternalUri
+Get-ClientAccessService | fl Name, AutodiscoverServiceInternalUri
 Get-OABVirtualDirectory | FL server,*url*
 Get-AutodiscoverVirtualDirectory | FL server,*url*
 Get-OutlookAnywhere | FL server,*hostname*


### PR DESCRIPTION
Just updated the Get-ClientAccessServer to Get-ClientAccessService as running the  Get-ClientAccessServer cmdlet throws the warning that the Get-ClientAccessServer cmdlet will be removed in a future version of Exchange. For more information, see http://go.microsoft.com/fwlink/p/?LinkId=254711.