### PR TITLE
Update microsoft-defender-antivirus-compatibility.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility.md
+++ b/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility.md
@@ -189,7 +189,6 @@ You can use one of several methods to confirm the state of Microsoft Defender An
  | Task Manager |  1. On a Windows device, open the Task Manager app.<br/>2. Select the **Details** tab.<br/>3. Look for **MsMpEng.exe** in the list. | 
  | Windows PowerShell <br/> (To confirm that Microsoft Defender Antivirus is running) |  1. On a Windows device, open Windows PowerShell. <br/>2. Run the following PowerShell cmdlet: `Get-Process`.<br/>3. Review the results. You should see **MsMpEng.exe** if Microsoft Defender Antivirus is enabled. | 
  | Windows PowerShell <br/>(To confirm that antivirus protection is in place) |  You can use the [Get-MpComputerStatus PowerShell cmdlet](/powershell/module/defender/get-mpcomputerstatus).<br/>1. On a Windows device, open Windows PowerShell.<br/>2. Run following PowerShell cmdlet:<br/> Get-MpComputerStatus \| select AMRunningMode <br/>3. Review the results. You should see either **Normal**, **Passive**, or **EDR Block Mode** if Microsoft Defender Antivirus is enabled on the endpoint.  | 
- | Command Prompt |  1. On a Windows device, open Command Prompt.<br/>2. Type `sc query windefend`, and then press Enter.<br/>3. Review the results to confirm that Microsoft Defender Antivirus is running in passive mode.  | 
 
 ## More details about Microsoft Defender Antivirus states
 

--- a/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility.md
+++ b/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility.md
@@ -14,7 +14,7 @@ ms.custom: nextgen
 ms.reviewer: mkaminska, pahuijbr
 manager: dansimp
 ms.technology: mde
-ms.date: 04/14/2022
+ms.date: 04/19/2022
 ms.collection: 
 - M365-security-compliance
 - m365initiative-defender-endpoint


### PR DESCRIPTION
At line 192, I have removed the entry "| Command Prompt |  1. On a Windows device, open Command Prompt.<br/>2. Type `sc query windefend`, and then press Enter.<br/>3. Review the results to confirm that Microsoft Defender Antivirus is running in passive mode.  | " because when using the mentioned method to query the windefend service you cannot see if Microsoft Defender Antivirus is running in passive or active mode. You can only see if the service is running or stopped when running the sc query windefend command.

<img width="422" alt="s1" src="https://user-images.githubusercontent.com/103999401/163989455-5a99801e-a6e0-4e5c-96f0-5ba83d77edf6.png">
.