### PR TITLE
Update per-group-guest-access.md

### DIFF
--- a/microsoft-365/solutions/per-group-guest-access.md
+++ b/microsoft-365/solutions/per-group-guest-access.md
@@ -91,7 +91,7 @@ By default, guests aren't visible in the Exchange Global Address List. Use the s
 Find the guest's ObjectID by running:
 
 ```PowerShell
-Get-AzureADUser -Filter "userType eq 'Guest'"
+get-AzureADUser -all $true | ?{$_.CreationType -eq "Invitation"}
 ```
 
 Then run the following using the appropriate values for ObjectID, GivenName, Surname, DisplayName, and TelephoneNumber.


### PR DESCRIPTION
Changing the cmdlet as Get-AzureADUser -Filter "userType eq 'Guest'" does not report the guest who are members.

Instead user we can use get-AzureADUser -all $true | ?{$_.CreationType -eq "Invitation"}