### PR TITLE
Remove single user in browser session requirement

### DIFF
--- a/microsoft-365/security/defender/mssp-access.md
+++ b/microsoft-365/security/defender/mssp-access.md
@@ -123,6 +123,3 @@ To implement a multi-tenant delegated access solution, take the following steps:
      At this point, analyst access has been provisioned, and each analyst should be able to access the customer's Microsoft 365 Defender portal:
 
     `https://security.microsoft.com/?tid=<CustomerTenantId>` with the permissions and roles they were assigned.
-
-> [!IMPORTANT]
-> Delegated access to Microsoft Defender for Endpoint in the Microsoft 365 Defender portal currently allows access to a single tenant per browser window.


### PR DESCRIPTION
Microsoft 365 Defender now supports accessing multiple tenants in the same browser session.