### PR TITLE
Update use-spam-notifications-to-release-and-report-quarantined-messa…

### DIFF
--- a/microsoft-365/security/office-365-security/use-spam-notifications-to-release-and-report-quarantined-messages.md
+++ b/microsoft-365/security/office-365-security/use-spam-notifications-to-release-and-report-quarantined-messages.md
@@ -48,8 +48,9 @@ For shared mailboxes, quarantine notifications are supported only for users who 
 > [!NOTE]
 > By default, messages that are quarantined as high confidence phishing, malware, by mail flow rules (also known as transport rules), or Safe Attachments policies in Defender for Office 365 are only available to admins (by default, the AdminOnlyAccessPolicy quarantine policy is used). For more information, see [Manage quarantined messages and files as an admin in EOP](manage-quarantined-messages-and-files.md).
 >
-> Currently, quarantine notifications are not supported for groups. here
-
+> Quarantine notifications for messages sent to distribution groups or mail-enabled security groups are sent to all group members.
+>
+> Quarantine notifications for messages sent to Microsoft 365 Groups are sent to all group members only if the **Send copies of group conversations and events to group members** setting is turned on.
 
 When you receive a quarantine notification, the following information is always available for each quarantined message:
 

--- a/microsoft-365/security/office-365-security/use-spam-notifications-to-release-and-report-quarantined-messages.md
+++ b/microsoft-365/security/office-365-security/use-spam-notifications-to-release-and-report-quarantined-messages.md
@@ -48,7 +48,7 @@ For shared mailboxes, quarantine notifications are supported only for users who 
 > [!NOTE]
 > By default, messages that are quarantined as high confidence phishing, malware, by mail flow rules (also known as transport rules), or Safe Attachments policies in Defender for Office 365 are only available to admins (by default, the AdminOnlyAccessPolicy quarantine policy is used). For more information, see [Manage quarantined messages and files as an admin in EOP](manage-quarantined-messages-and-files.md).
 >
-> Currently, quarantine notifications are not supported for groups.
+> Currently, quarantine notifications are not supported for groups. here
 
 When you receive a quarantine notification, the following information is always available for each quarantined message:
 


### PR DESCRIPTION
…ges.md

@chrisda  we can add something like this: 

Distribution Group. Messages sent to this Group will be expanded to group members and members will receive Quarantine Notifications email.
Unified Group. Messages sent to this Group will not be expanded, but if the setting "send a copy to group members" is enabled, all the members will receive an email copy.