### PR TITLE
Update run-advanced-query-api.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/run-advanced-query-api.md
+++ b/microsoft-365/security/defender-endpoint/run-advanced-query-api.md
@@ -33,7 +33,7 @@ ms.custom: api
 [!include[Improve request performance](../../includes/improve-request-performance.md)]
 
 > [!NOTE]
-> This API can only query tables belonging to Microsoft Defender for Endpoint. Tables belonging to other Microsoft 365 Defender services require the use of the [Microsoft 365 Defender Advanced hunting API](https://docs.microsoft.com/en-us/microsoft-365/security/defender/api-advanced-hunting?view=o365-worldwide)
+> This API can only query tables belonging to Microsoft Defender for Endpoint. Tables belonging to other Microsoft 365 Defender services require the use of the [Microsoft 365 Defender Advanced hunting API](/microsoft-365/security/defender/api-advanced-hunting).
 
 ## Limitations
 

--- a/microsoft-365/security/defender-endpoint/run-advanced-query-api.md
+++ b/microsoft-365/security/defender-endpoint/run-advanced-query-api.md
@@ -32,6 +32,9 @@ ms.custom: api
 
 [!include[Improve request performance](../../includes/improve-request-performance.md)]
 
+> [!NOTE]
+> This API can only query tables belonging to Microsoft Defender for Endpoint. Tables belonging to other Microsoft 365 Defender services require the use of the [Microsoft 365 Defender Advanced hunting API](https://docs.microsoft.com/en-us/microsoft-365/security/defender/api-advanced-hunting?view=o365-worldwide)
+
 ## Limitations
 
 1. You can only run a query on data from the last 30 days.


### PR DESCRIPTION
Add note stating that this API can only query advanced hunting tables belonging to MDE and not other M365 Defender services (such as MDO, MDI) and that the M365 Defender Advanced hunting API should be used for that.