### PR TITLE
Updated references from original creation

### DIFF
--- a/microsoft-365/solutions/end-life-cycle-groups-teams-sites-yammer.md
+++ b/microsoft-365/solutions/end-life-cycle-groups-teams-sites-yammer.md
@@ -120,7 +120,7 @@ While deletion of the group will also result in the deletion of any associated f
 
 ## OneNote
 
-The OneNote notebook included in a group is stored in the Site Assets library within the associated SharePoint site. While notebook files can sometimes be spread across multiple individual files, they can't be copied and opened independently. Instead, the contents of the OneNote notebook must be moved or exported using OneNote 2016.
+The OneNote notebook included in a group is stored in the Site Assets library within the associated SharePoint site. While notebook files can sometimes be spread across multiple individual files, they can't be copied and opened independently. Instead, the contents of the OneNote notebook must be moved or exported using the OneNote desktop client.
 
 **Move pages and sections to another notebook**
 
@@ -184,6 +184,7 @@ If the flow doesn't need to continue operating but it needs to be preserved for 
 ## Power BI
 
 Power BI data and workspaces can operate independently from groups and teams and like other workloads offer different ways of being off-boarded.
+Classic workspaces in Power BI are associated with a Microsoft 365 Group, whereas modern workspaces are not - and can merely share their content with the group (similar to a flow).
 
 **Copy reports to another workspace**
 
@@ -232,7 +233,7 @@ Additionally, files can be [moved to another location within SharePoint such as 
 
 Data stored within SharePoint lists can be [exported to an Excel spreadsheet](https://support.office.com/article/bfb2ea48-6118-4fa9-abb6-cced9424e5d9), and imported again to a list in another site.
 
-Alternatively, a third-party tool can be used to migrate the list between sites in order to retain function, list views, formatting, and other attributes.
+Alternatively, Power Automate or a third-party tool can be used to migrate the list between sites in order to retain function, list views, formatting, and other attributes.
 
 **“Export” wiki files**
 


### PR DESCRIPTION
A few things have changed from when I originally authored this article two years ago.
Several references have been updated:
- OneNote is no longer "OneNote 2016"
- There is a differentiation between classic and modern workspaces in Power BI and their association with M365 Groups
- Power Automate can be used to migrate SharePoint list contents