### PR TITLE
Update set-up-safe-links-policies.md

### DIFF
--- a/microsoft-365/security/office-365-security/set-up-safe-links-policies.md
+++ b/microsoft-365/security/office-365-security/set-up-safe-links-policies.md
@@ -137,7 +137,7 @@ Creating a custom Safe Links policy in the Microsoft 365 Defender portal creates
        - **Do not rewrite the following URLs in email** section: Click **Manage (nn) URLs** to allow access to specific URLs that would otherwise be blocked by Safe Links.
 
          > [!NOTE]
-         > Entries in the "Do not rewrite the following URLs" list are not scanned or wrapped by Safe Links during mail flow. Use [URL allow entries in the Tenant Allow/Block List](allow-block-urls.md#use-the-microsoft-365-defender-portal-to-create-allow-entries-for-urls-in-the-submissions-portal) so URLs are not scanned or wrapped by Safe Links during mail flow _and_ at time of click.
+         > Entries in the "Do not rewrite the following URLs" list are not scanned or wrapped by Safe Links during mail flow. Use allow URL entries in the Tenant Allow/Block List to override the Safe Links URL verdict.
 
      1. In the **Manage URLs to not rewrite** flyout that appears, click ![Add URLs icon.](../../media/m365-cc-sc-create-icon.png) **Add URLs**.
      2. In the **Add URLs** flyout that appears, type the URL or value that you want, select the entry that appears below the box, and then click **Save**. Repeat this step as many times as necessary.

--- a/microsoft-365/security/office-365-security/set-up-safe-links-policies.md
+++ b/microsoft-365/security/office-365-security/set-up-safe-links-policies.md
@@ -137,7 +137,7 @@ Creating a custom Safe Links policy in the Microsoft 365 Defender portal creates
        - **Do not rewrite the following URLs in email** section: Click **Manage (nn) URLs** to allow access to specific URLs that would otherwise be blocked by Safe Links.
 
          > [!NOTE]
-         > Entries in the "Do not rewrite the following URLs" list are not scanned or wrapped by Safe Links during mail flow. Use allow URL entries in the Tenant Allow/Block List to override the Safe Links URL verdict.
+         > Entries in the "Do not rewrite the following URLs" list are not scanned or wrapped by Safe Links during mail flow. Use [URL allow entries in the Tenant Allow/Block List](allow-block-urls.md#use-the-microsoft-365-defender-portal-to-create-allow-entries-for-urls-in-the-submissions-portal) to override the Safe Links URL verdict.
 
      1. In the **Manage URLs to not rewrite** flyout that appears, click ![Add URLs icon.](../../media/m365-cc-sc-create-icon.png) **Add URLs**.
      2. In the **Add URLs** flyout that appears, type the URL or value that you want, select the entry that appears below the box, and then click **Save**. Repeat this step as many times as necessary.


### PR DESCRIPTION
Update line 140 to state the following "Entries in the "Do not rewrite the following URLs" list are not scanned or wrapped by Safe Links during mail flow. Use allow URL entries in the Tenant Allow/Block List to override the Safe Links URL verdict".

Current verbiage does not reflect the actual behavior between Safe Links and TABL.