### PR TITLE
Update create-a-custom-sensitive-information-type-in-scc-powershell.md

### DIFF
--- a/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
+++ b/microsoft-365/compliance/create-a-custom-sensitive-information-type-in-scc-powershell.md
@@ -312,7 +312,7 @@ Note that for email, the message body and each attachment are treated as separat
 
 The more evidence that a pattern requires, the more confidence you have that an actual entity (such as employee ID) has been identified when the pattern is matched. For example, you have more confidence in a pattern that requires a nine-digit ID number, hire date, and keyword in close proximity, than you do in a pattern that requires only a nine-digit ID number.
 
-The Pattern element has a required confidenceLevel attribute. You can think of the value of confidenceLevel (an integer between 1 and 100) as a unique ID for each pattern in an entity — the patterns in an entity must have different confidence levels that you assign. The precise value of the integer doesn't matter — simply pick numbers that make sense to your compliance team. After you upload your custom sensitive information type and then create a policy, you can reference these confidence levels in the conditions of the rules that you create.
+The Pattern element has a required confidenceLevel attribute. You can think of the value of confidenceLevel (a value among 65/75/85 indicating Low/Medium/High confidence levels) as a unique ID for each pattern in an entity. After you upload your custom sensitive information type and then create a policy, you can reference these confidence levels in the conditions of the rules that you create.
 
 ![XML markup showing Pattern elements with different values for confidenceLevel attribute.](../media/sit-xml-markedup-2.png)
 


### PR DESCRIPTION
@chrfox Two corrections in this document.
1. Confidence level can only be 65/75/85. Numeric values other than these are not allowed.
2. Each pattern need not have different confidence levels.