### PR TITLE
Fix errors in managed preferences docs + Re-word mac release notes

### DIFF
--- a/microsoft-365/security/defender-endpoint/linux-preferences.md
+++ b/microsoft-365/security/defender-endpoint/linux-preferences.md
@@ -99,8 +99,8 @@ Enables or disables file hash computation feature. When this feature is enabled,
 |Description|Value|
 |---|---|
 |**Key**|enableFileHashComputation|
-|**Data type**|String|
-|**Possible values**|disabled (default) <p> enabled|
+|**Data type**|Boolean|
+|**Possible values**|false (default) <p> true|
 |**Comments**|Available in Defender for Endpoint version 101.73.77 or higher.|
   
 #### Run a scan after definitions are updated

--- a/microsoft-365/security/defender-endpoint/mac-preferences.md
+++ b/microsoft-365/security/defender-endpoint/mac-preferences.md
@@ -97,8 +97,8 @@ Enables or disables file hash computation feature. When this feature is enabled,
 |---|---|
 |**Domain**|`com.microsoft.wdav`|
 |**Key**|enableFileHashComputation|
-|**Data type**|String|
-|**Possible values**|disabled (default) <p> enabled|
+|**Data type**|Boolean|
+|**Possible values**|false (default) <p> true|
 |**Comments**|Available in Defender for Endpoint version 101.73.77 or higher.|
 
 #### Run a scan after definitions are updated

--- a/microsoft-365/security/defender-endpoint/mac-whatsnew.md
+++ b/microsoft-365/security/defender-endpoint/mac-whatsnew.md
@@ -43,7 +43,7 @@ For more information on Microsoft Defender for Endpoint on other operating syste
 
 **What's new**
 
-- Mac TP in Block mode causing device hang on shutdown/ crashes on reboot
+- Bug fix - Mac TP in Block mode causing device hang on shutdown/crashes on reboot
 - Add a mdatp command-line switch to view the on-demand scan history
 - Improve Performance of Device Owner on MacOs
 - Ready for macOS Ventura (13.0)


### PR DESCRIPTION
There was an error in managed preferences documentation on both Linux and Mac, which have been fixed in this PR. In mac release notes for MDE version 101.82.21, there was an entry that needed to be re-worded to avoid confusion. 