### PR TITLE
Update attack-surface-reduction-rules-reference.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/attack-surface-reduction-rules-reference.md
+++ b/microsoft-365/security/defender-endpoint/attack-surface-reduction-rules-reference.md
@@ -216,7 +216,7 @@ When the allow button is clicked, the block will be suppressed for 24 hours. Aft
 You can also set a rule in warn mode via PowerShell by specifying the AttackSurfaceReductionRules_Actions as "Warn". For example:
 
 ```powershell
--command "& {&'Add-MpPreference' -AttackSurfaceReductionRules_Ids 56a863a9-875e-4185-98a7-b882c64b5ce5 -AttackSurfaceReductionRules_Actions Warn"} 
+Add-MpPreference -AttackSurfaceReductionRules_Ids 56a863a9-875e-4185-98a7-b882c64b5ce5 -AttackSurfaceReductionRules_Actions Warn
 ```
 
 ## Per rule descriptions


### PR DESCRIPTION
Corrected PowerShell command for setting a rule in Warn mode.  As it was written, it would produce an error if run, both in PowerShell and in a cmd window.

If invoked from a cmd window, a working command would be
`powershell -command "Add-MpPreference -AttackSurfaceReductionRules_Ids 56a863a9-875e-4185-98a7-b882c64b5ce5 -AttackSurfaceReductionRules_Actions Warn"`