### PR TITLE
Update ediscovery-content-search-reference.md

### DIFF
--- a/microsoft-365/compliance/ediscovery-content-search-reference.md
+++ b/microsoft-365/compliance/ediscovery-content-search-reference.md
@@ -211,8 +211,6 @@ If the Exchange Online license (or the entire Microsoft 365 license) is removed 
 - If an existing content search includes a mailbox in which the license is removed, no search results from the disconnected mailbox will be returned if you rerun the content search.
 - If you use the **New-ComplianceSearch** cmdlet to create a content search and specify a disconnected mailbox as the Exchange content location to search, the content search won't return any search results from the disconnected mailbox.
 
-If you need to preserve the data in a disconnected mailbox so that it's searchable, you must place a hold on the mailbox before removing the license. This preserves the data and keeps the disconnected mailbox searchable until the hold is removed. For more information about holds, see [How to identify the type of hold placed on an Exchange Online mailbox](ediscovery-identify-a-hold-on-an-exchange-online-mailbox.md).
-
 ## Searching for content in a SharePoint multi-geo environment
 
 If it's necessary for an eDiscovery manager to search for content in SharePoint and OneDrive in different regions in a [SharePoint multi-geo environment](../enterprise/multi-geo-capabilities-in-onedrive-and-sharepoint-online-in-microsoft-365.md), then you need to do the following things to make that happen:


### PR DESCRIPTION
This entire paragraph needs to be removed. You CANNOT remove the license from a mailbox that is on hold. Doing so will introduce a validation error in Azure and the mailbox will fail to be disconnected/disabled due to the hold. This is NOT a supported state. Disconnected or de-licensed mailboxes are not searchable. Period. If content in a mailbox needs to be searchable, it must either be an active licensed user, a Shared mailbox (no license required) or be turned into an Inactive mailbox.