### PR TITLE
Update ediscovery-configure-edge-to-export-search-results.md

### DIFF
--- a/microsoft-365/compliance/ediscovery-configure-edge-to-export-search-results.md
+++ b/microsoft-365/compliance/ediscovery-configure-edge-to-export-search-results.md
@@ -20,7 +20,7 @@ search.appverid:
 
 # Use the eDiscovery Export Tool in Microsoft Edge
 
-As a result of recent changes to the newest version of Microsoft Edge, ClickOnce support is no longer enabled by default. To continue using the eDiscovery Export Tool to download Content Search or eDiscovery search results, you either need to use [Microsoft Internet Explorer](https://support.microsoft.com/help/17621/internet-explorer-downloads) or enable ClickOnce support in the newest version of Microsoft Edge.
+As a result of recent changes to the newest version of Microsoft Edge, ClickOnce support is no longer enabled by default. To continue using the eDiscovery Export Tool to download Content Search or eDiscovery search results, you need to enable ClickOnce support in the newest version of Microsoft Edge.
 
 [!INCLUDE [purview-preview](../includes/purview-preview.md)]
 


### PR DESCRIPTION
Removed reference of IE as it is not supported after Feb 14 and renders a blank page now.

fixes#https://github.com/MicrosoftDocs/microsoft-365-docs/issues/10812