### PR TITLE
Update ediscovery-close-or-delete-case.md

### DIFF
--- a/microsoft-365/compliance/ediscovery-close-or-delete-case.md
+++ b/microsoft-365/compliance/ediscovery-close-or-delete-case.md
@@ -72,11 +72,11 @@ Before you can delete a case (whether it's active or closed), you must first del
 
 To delete holds associated with a case:
 
-1. Go the **Data Source** tab in the eDiscovery (Premium) case and release Holds from all custodians
-2. Close the case from **Settings** tab
-3. Under **Holds** tab the Delete button gets enabled after the case is closed
-4. Delete the holds and wait for the job to be completely deleted 
-5. Finally, go to the settings and delete the case.
+1. Go to the **Data Source** tab in the eDiscovery (Premium) case and release holds from all custodians.
+2. Close the case from the **Settings** tab.
+3. The **Delete** button under the **Holds** tab is enabled after the case is closed.
+4. Delete the holds and wait for the job to be completely deleted.
+5. Finally, go to **Settings** and delete the case.
 
 To delete a case:
 

--- a/microsoft-365/compliance/ediscovery-close-or-delete-case.md
+++ b/microsoft-365/compliance/ediscovery-close-or-delete-case.md
@@ -72,9 +72,11 @@ Before you can delete a case (whether it's active or closed), you must first del
 
 To delete holds associated with a case:
 
-1. Go the **Holds** tab in the eDiscovery (Premium) case that you want to delete.
-2. Select the hold that you want to delete.
-3. On the flyout page, select **Delete hold**.
+1. Go the **Data Source** tab in the eDiscovery (Premium) case and release Holds from all custodians
+2. Close the case from **Settings** tab
+3. Under **Holds** tab the Delete button gets enabled after the case is closed
+4. Delete the holds and wait for the job to be completely deleted 
+5. Finally, go to the settings and delete the case.
 
 To delete a case:
 


### PR DESCRIPTION
The steps to delete a Hold have recently changed.
With latest updates, it is needed to close the case before the "Delete" button is enabled to delete a Hold

Internal VSO item for reference: https://o365exchange.visualstudio.com/DefaultCollection/IP%20Engineering/_workitems/edit/3337781