### PR TITLE
Removal of duplicate entry for enableFileHashComputation

### DIFF
--- a/microsoft-365/security/defender-endpoint/linux-preferences.md
+++ b/microsoft-365/security/defender-endpoint/linux-preferences.md
@@ -92,17 +92,6 @@ Determines whether behavior monitoring and blocking capability is enabled on the
 |**Possible values**|disabled (default) <p> enabled|
 |**Comments**|Available in Defender for Endpoint version 101.45.00 or higher.|
 
-#### Configure file hash computation feature
-
-Enables or disables file hash computation feature. When this feature is enabled, Defender for Endpoint will compute hashes for files it scans. Note that enabling this feature might impact device performance. For more details, please refer to: [Create indicators for files](indicator-file.md).
-
-|Description|Value|
-|---|---|
-|**Key**|enableFileHashComputation|
-|**Data type**|Boolean|
-|**Possible values**|true (default) <p> false|
-|**Comments**|Available in Defender for Endpoint version 101.73.77 or higher.|
-  
 #### Run a scan after definitions are updated
 
 Specifies whether to start a process scan after new security intelligence updates are downloaded on the device. Enabling this setting will trigger an antivirus scan on the running processes of the device.

--- a/microsoft-365/security/defender-endpoint/linux-preferences.md
+++ b/microsoft-365/security/defender-endpoint/linux-preferences.md
@@ -10,7 +10,7 @@ ms.pagetype: security
 ms.author: dansimp
 author: dansimp
 ms.localizationpriority: medium
-ms.date: 11/03/2022
+ms.date: 02/09/2023
 manager: dansimp
 audience: ITPro
 ms.collection: 


### PR DESCRIPTION
Removed wrong entry about enableFileHashComputation this doc had two entries regarding enableFileHashComputation, one stating the default value was true(which was not correct as per tests made) and another saying that the default value was false which was the correct value