### PR TITLE
Update customer-key-availability-key-roll.md

### DIFF
--- a/microsoft-365/compliance/customer-key-availability-key-roll.md
+++ b/microsoft-365/compliance/customer-key-availability-key-roll.md
@@ -18,7 +18,7 @@ description: "Learn how to roll the customer root keys stored in Azure Key Vault
 # Roll or rotate a Customer Key or an availability key
 
 > [!CAUTION]
-> Only roll an encryption key that you use with Customer Key when your security or compliance requirements dictate that you must roll the key. In addition, do not delete any keys that are or were associated with policies. When you roll your keys, there will be content encrypted with the previous keys. For example, while active mailboxes will be re-encrypted frequently, inactive, disconnected, and disabled mailboxes may still be encrypted with the previous keys. SharePoint Online performs backup of content for restore and recovery purposes, so there may still be archived content using older keys.
+> Only roll an encryption key that you use with Customer Key when your security or compliance requirements dictate that you must roll the key. In addition, do not delete or disable any keys that are or were associated with policies. When you roll your keys, there will be content encrypted with the previous keys. For example, while active mailboxes will be re-encrypted frequently, inactive, disconnected, and disabled mailboxes may still be encrypted with the previous keys. SharePoint Online performs backup of content for restore and recovery purposes, so there may still be archived content using older keys.
 
 [!INCLUDE [purview-preview](../includes/purview-preview.md)]
 
@@ -78,6 +78,8 @@ To instruct Customer Key to use the new key to encrypt mailboxes, run the Set-Da
    ```powershell
    Set-DataEncryptionPolicy -Identity <DataEncryptionPolicyID> -Refresh
    ```
+
+   While this cmdlet starts the key roll operation for Exchange Online, the action doesn't complete immediately.
 
 2. To check the value for the DataEncryptionPolicyID property for the mailbox, use the steps in [Determine the DEP assigned to a mailbox](customer-key-manage.md#determine-the-dep-assigned-to-a-mailbox). The value for this property changes once the service applies the updated key.
   


### PR DESCRIPTION
We had a large customer 125k seats Rave case # 35048920 that initiated the roll process for the first time. They disabled the old key and saw clients unable to access mailboxes in growing numbers - re-enabled the disabled rolled key and were able to reconnect in 5 minutes for all mailboxes affected.  We only indicated not to delete this change changes that to delete or disable in the warning at the top. and also adds under Exchange DEP section "While this cmdlet starts the key roll operation for Exchange Online, the action doesn't complete immediately."