### PR TITLE
Update named-entities-learn.md

### DIFF
--- a/microsoft-365/compliance/named-entities-learn.md
+++ b/microsoft-365/compliance/named-entities-learn.md
@@ -52,7 +52,7 @@ Bundled named entity SITs detect all possible matches. Use them as broad criteri
 Unbundled named entity SITs have a narrower focus, like a single country. Use them when you need a DLP policy with a narrower detection scope.
 
 > [!Note]
-> To use bundled SITs, you must activate [Advanced scanning and protection](dlp-configure-endpoint-settings.md) for the relevant [data loss prevention endpoints](dlp-configure-endpoint-settings.md) before they will be discoverable. 
+> To use the named entity SITs, you must activate [Advanced scanning and protection](dlp-configure-endpoint-settings.md) for the relevant [data loss prevention endpoints](dlp-configure-endpoint-settings.md) before they will be discoverable. 
  
 Here are some examples of named entity SITs. You can find all of them in [Sensitive information type entity definitions](sensitive-information-type-entity-definitions.md).
 


### PR DESCRIPTION
Updated content to make clear that any named entity SIT rather than just the bundled ones require adv classification to be enabled for End Point DLP. @chrfox to review.