### PR TITLE
Update get-started-with-data-lifecycle-management.md

### DIFF
--- a/microsoft-365/compliance/get-started-with-data-lifecycle-management.md
+++ b/microsoft-365/compliance/get-started-with-data-lifecycle-management.md
@@ -5,7 +5,7 @@ f1.keywords:
 ms.author: cabailey
 author: cabailey
 manager: laurawi
-ms.date: 02/27/2023
+ms.date: 03/07/2023
 audience: Admin
 ms.topic: conceptual
 ms.service: O365-seccomp
@@ -67,7 +67,7 @@ For permissions to manage mailboxes for archiving, inactive mailboxes, and impor
 
 Members of your compliance team who will create and manage retention policies and retention labels need permissions to the <a href="https://go.microsoft.com/fwlink/p/?linkid=2077149" target="_blank">Microsoft Purview compliance portal</a>. By default, the tenant admin (global administrator) has access to this location and can give compliance officers and other people access without giving them all the permissions of a tenant admin. To grant permissions for this limited administration, we recommend that you add users to the **Compliance Administrator** admin role group.
 
-Alternatively to using this default role, you can create a new role group and add the **Retention Management** role to this group. For a read-only role, use **View-Only Retention Management**. To use [adaptive policy scopes](retention.md#adaptive-or-static-policy-scopes-for-retention), you'll also need the **Scope Manager** role.
+Alternatively to using this default role, you can create a new role group and add the **Retention Management** role to this group. For a read-only role, use **View-Only Retention Management**.
 
 For instructions to add users to the default roles or create your own role groups, see [Permissions in the Microsoft Purview compliance portal](microsoft-365-compliance-center-permissions.md).
 


### PR DESCRIPTION
Confirmed by engineering - bug fix rolling out so Scope Manager shouldn't be needed if have Retention Management, so remove from documentation.