### PR TITLE
Update retention-policies-teams.md

### DIFF
--- a/microsoft-365/compliance/retention-policies-teams.md
+++ b/microsoft-365/compliance/retention-policies-teams.md
@@ -48,7 +48,9 @@ For other workloads, see:
 
 Teams chats messages, channel messages, and private channel messages can be deleted by using retention policies for Teams, and in addition to the text in the messages, the following items can be retained for compliance reasons: [Video clips](https://support.microsoft.com/office/record-a-video-clip-in-teams-0c57dae5-2974-4214-9c46-7a2136386f1c), embedded images, tables, hypertext links, links to other Teams messages and files, and [card content](/microsoftteams/platform/task-modules-and-cards/what-are-cards).
 
-Newly created call data records, which are system-generated messages that contain [metadata for meetings and calls](/MicrosoftTeams/ediscovery-investigation#teams-metadata) are also supported.
+Call data records, which are system-generated messages that contain [metadata for meetings and calls](/MicrosoftTeams/ediscovery-investigation#teams-metadata) are  supported.
+
+Control messages are system-generated messages that contain [information about actions taken in Teams](/graph/system-messages#supported-system-message-events). The control message events for naming and for re-naming a chat are supported. Additional control messages types may be supported in the future.
 
 These chat messages and private channel messages include all the names of the people in the conversation, and channel messages include the team name and the message title (if supplied). 
 

--- a/microsoft-365/compliance/retention-policies-teams.md
+++ b/microsoft-365/compliance/retention-policies-teams.md
@@ -48,9 +48,9 @@ For other workloads, see:
 
 Teams chats messages, channel messages, and private channel messages can be deleted by using retention policies for Teams, and in addition to the text in the messages, the following items can be retained for compliance reasons: [Video clips](https://support.microsoft.com/office/record-a-video-clip-in-teams-0c57dae5-2974-4214-9c46-7a2136386f1c), embedded images, tables, hypertext links, links to other Teams messages and files, and [card content](/microsoftteams/platform/task-modules-and-cards/what-are-cards).
 
-Call data records, which are system-generated messages that contain [metadata for meetings and calls](/MicrosoftTeams/ediscovery-investigation#teams-metadata) are  supported.
+Call data records, which are system-generated messages that contain [metadata for meetings and calls](/MicrosoftTeams/ediscovery-investigation#teams-metadata) are supported.
 
-Control messages are system-generated messages that contain [information about actions taken in Teams](/graph/system-messages#supported-system-message-events). The control message events for naming and for re-naming a chat are supported. Additional control messages types may be supported in the future.
+The control message events for naming and for renaming a chat are supported. Control messages are system-generated messages that contain [information about actions taken in Teams](/graph/system-messages#supported-system-message-events).
 
 These chat messages and private channel messages include all the names of the people in the conversation, and channel messages include the team name and the message title (if supplied). 
 


### PR DESCRIPTION
Added text  for control messages support; removed "new" from CDRs to align with rollout of support for older types now too.