### PR TITLE
Update administering-a-multi-geo-environment.md

### DIFF
--- a/microsoft-365/enterprise/administering-a-multi-geo-environment.md
+++ b/microsoft-365/enterprise/administering-a-multi-geo-environment.md
@@ -32,9 +32,6 @@ The SharePoint admin center has a [**Geo locations** tab](https://go.microsoft.c
 
 A unified [Audit log](https://support.office.com/article/0d4d0f35-390b-4518-800e-0c7ec95e946c) for all your _Satellite Geography_ locations is available from the Microsoft 365 audit log search page. You can see all the audit log entries from across geo locations, for example, NAM & EUR users' activities will show up in one org view and then you can apply existing filters to see specific user's activities.
 
-> [!NOTE]
-> Exchange admin audit events are only available for the default location.
-
 ## BCS, Secure Store, Apps
 
 BCS, Secure Store, and Apps all have separate instances in each satellite location, therefore the SharePoint Online administrator should manage and configure these services separately from each satellite location.


### PR DESCRIPTION
Removing note as "Exchange admin audit events are only available for the default location." in the below public doc as this feature is now enabled for all locations so we don't need this note anymore. 