### PR TITLE
Devices currently in troubleshooting mode

### DIFF
--- a/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode.md
+++ b/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode.md
@@ -140,6 +140,7 @@ DeviceEvents
 
 ```kusto
 DeviceEvents
+| where Timestamp > ago(3h) // troubleshooting mode automatically disables after 3 hours (https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode)
 | where ActionType == "AntivirusTroubleshootModeEvent"
 | extend _tsmodeproperties = parse_json(AdditionalFields)
 | where _tsmodeproperties.TroubleshootingStateChangeReason contains "started"

--- a/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode.md
+++ b/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode.md
@@ -1,13 +1,9 @@
 ---
 title: Get started with troubleshooting mode in Microsoft Defender for Endpoint 
 description: Turn on the Microsoft Defender for Endpoint troubleshooting mode to address various antivirus issues.
-keywords: antivirus, troubleshoot, troubleshooting mode, tamper protection, compatibility
 search.product: eADQiWindows 10XVcnh
 search.appverid: met150
 ms.service: microsoft-365-security
-ms.mktglfcycl: manage
-ms.sitesec: library
-ms.pagetype: security
 ms.author: dansimp
 author: dansimp
 ms.localizationpriority: medium
@@ -18,7 +14,7 @@ ms.collection:
 - tier2
 ms.topic: conceptual
 ms.subservice: mde
-ms.date: 03/06/2023
+ms.date: 04/18/2023
 ---
 
 # Get started with troubleshooting mode in Microsoft Defender for Endpoint 

--- a/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode.md
+++ b/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode.md
@@ -136,7 +136,7 @@ DeviceEvents
 
 ```kusto
 DeviceEvents
-| where Timestamp > ago(3h) // troubleshooting mode automatically disables after 3 hours (https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/enable-troubleshooting-mode)
+| where Timestamp > ago(3h) // troubleshooting mode automatically disables after 3 hours 
 | where ActionType == "AntivirusTroubleshootModeEvent"
 | extend _tsmodeproperties = parse_json(AdditionalFields)
 | where _tsmodeproperties.TroubleshootingStateChangeReason contains "started"


### PR DESCRIPTION
The KQL for Devices currently in troubleshooting mode is misleading. Either the title should state "Lastest timestamp of when device entered troubleshooting mode" or modify the KQL as proposed