### PR TITLE
Update use-network-upload-to-import-pst-files.md

### DIFF
--- a/microsoft-365/compliance/use-network-upload-to-import-pst-files.md
+++ b/microsoft-365/compliance/use-network-upload-to-import-pst-files.md
@@ -155,7 +155,7 @@ Here are examples of the syntax for the AzCopy tool using actual values for each
 This is an example for a source directory located on file server or local computer.
 
 ```powershell
-azcopy.exe copy "\\FILESERVER1\PSTs" "https://3c3e5952a2764023ad14984.blob.core.windows.net/ingestiondata?sv=2012-02-12&amp;se=9999-12-31T23%3A59%3A59Z&amp;sr=c&amp;si=IngestionSasForAzCopy201601121920498117&amp;sig=Vt5S4hVzlzMcBkuH8bH711atBffdrOS72TlV1mNdORg%3D"
+azcopy.exe copy "\\FILESERVER1\PSTs" "https://3c3e5952a2764023ad14984.blob.core.windows.net/ingestiondata?sv=2012-02-12&amp;se=9999-12-31T23%3A59%3A59Z&amp;sr=c&amp;si=IngestionSasForAzCopy201601121920498117&amp;sig=Vt5S4hVzlzMcBkuH8bH711atBffdrOS72TlV1mNdORg%3D" --recursive
 ```
 
 ### Example 2


### PR DESCRIPTION
Added --recursive to example 1 as it errors out with failed to perform copy command due to error: failed to initialize enumerator: cannot use directory as source without --recursive or a trailing wildcard (/*

fixes https://github.com/MicrosoftDocs/microsoft-365-docs/issues/11715