### PR TITLE
Remove 14 character requirement

### DIFF
--- a/microsoft-365/admin/misc/password-policy-recommendations.md
+++ b/microsoft-365/admin/misc/password-policy-recommendations.md
@@ -66,8 +66,6 @@ Good password practices fall into a few broad categories:
 
 The primary goal of a more secure password system is password diversity. You want your password policy to contain lots of different and hard to guess passwords. Here are a few recommendations for keeping your organization as secure as possible.
 
-- Maintain a 14-character minimum length requirement
-
 - Don't require character composition requirements. For example, \*&amp;(^%$
 
 - Don't require mandatory periodic password resets for user accounts


### PR DESCRIPTION
The guidance in this doc does not align with our more updated recommendations for protecting M365 admins.  M365 admins should be cloud-only, password-less.  In addition, AAD only environments cannot enforce a 14-character password minimum.  I've consulted with the AAD PG on this and happy to discuss in detail as to why this recommendation is not valid.  Thanks!