### PR TITLE
Update sit-get-started-exact-data-match-hash-upload.md

### DIFF
--- a/microsoft-365/compliance/sit-get-started-exact-data-match-hash-upload.md
+++ b/microsoft-365/compliance/sit-get-started-exact-data-match-hash-upload.md
@@ -133,7 +133,7 @@ This computer must have direct access to your Microsoft 365 tenant.
 
 4. Sign in with your work or school account for Microsoft 365 that was added to the EDM_DataUploaders security group. Your tenant information is extracted from the user account to make the connection.
 
-   OPTIONAL: If you used the Exact Data Match schema and sensitive information type wizard to create your schema, you ***must*** download it for use in this procedure if you haven't already. Run this command in a Command Prompt window:
+   IMPORTANT: If you used the Exact Data Match schema and sensitive information type wizard to create your schema, you ***must*** download it for use in this procedure if you haven't already. Run this command in a Command Prompt window:
 
    ```dos
    EdmUploadAgent.exe /SaveSchema /DataStoreName <schema name> /OutputDir <path to output folder>


### PR DESCRIPTION
@chrfox @kmkoenen In response to a recent customer issue, updating the doc to make clear that the admin MUST download the schema before hashing the EDM data after creating/editing the schema via the EDM UI.