### PR TITLE
Update mac-schedule-scan.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/mac-schedule-scan.md
+++ b/microsoft-365/security/defender-endpoint/mac-schedule-scan.md
@@ -3,12 +3,10 @@ title: How to schedule scans with Microsoft Defender for Endpoint on macOS
 description: Learn how to schedule an automatic scanning time for Microsoft Defender for Endpoint in macOS to better protect your organization's assets.
 keywords: microsoft, defender, Microsoft Defender for Endpoint, mac, scans, antivirus, big sur, monterey, ventura, mde for mac
 ms.service: microsoft-365-security
-ms.mktglfcycl: deploy
-ms.sitesec: library
-ms.pagetype: security
 ms.author: dansimp
 author: dansimp
 ms.localizationpriority: medium
+ms.date: 07/13/2023
 manager: dansimp
 audience: ITPro
 ms.collection: 

--- a/microsoft-365/security/defender-endpoint/mac-schedule-scan.md
+++ b/microsoft-365/security/defender-endpoint/mac-schedule-scan.md
@@ -62,8 +62,6 @@ The following code shows the schema you need to use to schedule a quick scan.
         <true/>
         <key>StartCalendarInterval</key>
         <dict>
-            <key>Day</key>
-            <integer>3</integer>
             <key>Hour</key>
             <integer>2</integer>
             <key>Minute</key>
@@ -101,8 +99,6 @@ The following code shows the schema you need to use to schedule a quick scan.
         <true/>
         <key>StartCalendarInterval</key>
         <dict>
-            <key>Day</key>
-            <integer>3</integer>
             <key>Hour</key>
             <integer>2</integer>
             <key>Minute</key>


### PR DESCRIPTION
removed the day from the Plist as day and weekday are usually competing schedule items and are generally not used in conjunction with each other when calling a process

Fixes https://github.com/MicrosoftDocs/microsoft-365-docs/issues/12416