### PR TITLE
Update configure-local-policy-overrides-microsoft-defender-antivirus.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/configure-local-policy-overrides-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-local-policy-overrides-microsoft-defender-antivirus.md
@@ -91,6 +91,9 @@ By default, lists that have been configured in local group policy and the Window
 
 4. Double-click **Configure local administrator merge behavior for lists** and set the option to **Disabled**. Then select **OK**.
 
+> [!NOTE]
+> For "Administrative Templates (.admx) for Windows 11 2022 Update (22H2)" and "Administrative Templates (.admx) for Windows 10 November 2021 Update (21H2)" templates, **Configure local administrator merge behavior for lists** should be set to **Enabled** to disable the local administrator merge behavior.
+
 ### Use Microsoft Intune to disable local list merging
 
 1. In the [Microsoft Intune admin center](https://endpoint.microsoft.com), select **Endpoint security** > **Antivirus**.

--- a/microsoft-365/security/defender-endpoint/configure-local-policy-overrides-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-local-policy-overrides-microsoft-defender-antivirus.md
@@ -88,7 +88,7 @@ By default, lists that have been configured in local group policy and the Window
 4. Double-click **Configure local administrator merge behavior for lists** and set the option to **Disabled**. Then select **OK**.
 
 > [!NOTE]
-> For "Administrative Templates (.admx) for Windows 11 2022 Update (22H2)" and "Administrative Templates (.admx) for Windows 10 November 2021 Update (21H2)" templates, **Configure local administrator merge behavior for lists** should be set to **Enabled** to disable the local administrator merge behavior.
+> For "Administrative Templates (.admx) for Windows 11 2022 Update (22H2)" and "Administrative Templates (.admx) for Windows 10 November 2021 Update (21H2)" templates, set **Configure local administrator merge behavior for lists** to **Enabled** to disable the local administrator merge behavior.
 
 ### Use Microsoft Intune to disable local list merging
 

--- a/microsoft-365/security/defender-endpoint/configure-local-policy-overrides-microsoft-defender-antivirus.md
+++ b/microsoft-365/security/defender-endpoint/configure-local-policy-overrides-microsoft-defender-antivirus.md
@@ -1,18 +1,14 @@
 ---
 title: Configure local overrides for Microsoft Defender Antivirus settings
 description: Enable or disable users from locally changing settings in Microsoft Defender Antivirus.
-keywords: local override, local policy, group policy, gpo, lockdown,merge, lists
 ms.service: microsoft-365-security
 ms.subservice: mde
-ms.mktglfcycl: manage
-ms.sitesec: library
-ms.pagetype: security
 ms.localizationpriority: medium
 author: denisebmsft
 ms.author: deniseb
 ms.topic: conceptual
 ms.custom: nextgen
-ms.date: 08/02/2022
+ms.date: 07/13/2023
 ms.reviewer: 
 manager: dansimp
 ms.collection: 


### PR DESCRIPTION
added a note for "Use Group Policy to disable local list merging" as options have changed with the latest GP

Fixes https://github.com/MicrosoftDocs/microsoft-365-docs/issues/12419