### PR TITLE
Update microsoft-defender-endpoint-linux.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/microsoft-defender-endpoint-linux.md
+++ b/microsoft-365/security/defender-endpoint/microsoft-defender-endpoint-linux.md
@@ -93,7 +93,7 @@ If you experience any installation failures, refer to [Troubleshooting installat
   - CentOS 6.7 or higher (Preview)
   - CentOS 7.2 or higher
   - Ubuntu 16.04 LTS or higher LTS
-  - Debian 9 or higher
+  - Debian 9 - 11
   - SUSE Linux Enterprise Server 12 or higher
   - Oracle Linux 7.2 or higher
   - Oracle Linux 8.x


### PR DESCRIPTION
The current description reads that Debian 12 also supports MDE on Linux, but in fact, it does not because the mdatp package has not been released.

Made changes to the System requirements

Fixes https://github.com/MicrosoftDocs/microsoft-365-docs/issues/12659
