### PR TITLE
Fixed Exchange admin cannot create Security Groups.

### DIFF
--- a/microsoft-365/admin/add-users/about-admin-roles.md
+++ b/microsoft-365/admin/add-users/about-admin-roles.md
@@ -110,7 +110,7 @@ You'll probably only need to assign the following roles in your organization. By
 | Global admin  | Create, Read, Update, Delete  | Create, Read, Update, Delete | Create, Read, Update, Delete | Create, Read, Update, Delete |
 | Global reader  | Read | Read  | Read | Read |
 | User admin  | Create, Read, Update, Delete, ***Can't update EXO properties*** | Create, Read, Update, Delete | Read | Read |
-| Exchange admin  | Create, Read, Update, Delete | Create, Read, Update, Delete - *only groups they own*  | Create, Read, Update, Delete | Create, Read, Update, Delete |
+| Exchange admin  | Create, Read, Update, Delete | Read, Update - *only groups they own*, Delete - *only groups they own*  | Create, Read, Update, Delete | Create, Read, Update, Delete |
 | Teams admin  | Create, Read, Update, Delete, ***Can't update EXO properties*** | Create, Read, Update, Delete - _only groups they own_  | Read | Read |
 | SharePoint admin  | Create, Read, Update, Delete, ***Can't update EXO properties*** | Create, Read, Update, Delete -_only groups they own_  | Read | Read |
 | Billing admin  | Read | Read | Read  | Read |


### PR DESCRIPTION
I have verified that Exchange admin cannot create security groups in the Entra ID portal and Microsoft 365 admin center. The table stated that they could be created. I request a correction.

<!--
Microsoft Entra rebrand: Please do not submit pull requests containing branding updates from Azure Active Directory, Azure AD, AAD, etc, to their respective Microsoft Entra equivalents at this time. 

Microsoft Entra rebranding is being coordinated across the Learn platform and will be applied to this repo automatically when we receive confirmation that product UIs have been updated. If you have questions regarding the rebrand project, contact dstrome.

This text can be deleted.
-->
