### PR TITLE
Tenant Allow/Block list: Improve wording for Allow entries

### DIFF
--- a/microsoft-365/security/office-365-security/tenant-allow-block-list-about.md
+++ b/microsoft-365/security/office-365-security/tenant-allow-block-list-about.md
@@ -102,7 +102,7 @@ By default, allow entries for domains and email addresses, files, and URLs exist
 > [!IMPORTANT]
 > Microsoft does not allow you to create allow entries directly. Unnecessary allow entries expose your organization to malicious email which could have been filtered by the system.
 >
-> Microsoft manages the creation of allow entries from the **Submissions** page. Allow entries are added during mail flow based on the filters that determined the message was malicious. For example, if the sender email address and a URL in the message were determined to be bad, an allow entry is created for the sender (email address or domain) and the URL.
+> Microsoft manages the creation of allow entries from the **Submissions** page at <https://security.microsoft.com/reportsubmission>. Allow entries are added during mail flow based on the filters that determined the message was malicious. For example, if the sender email address and a URL in the message were determined to be bad, an allow entry is created for the sender (email address or domain) and the URL.
 >
 > When the entity is encountered again (during mail flow or time of click), all filters associated with that entity are skipped.
 >


### PR DESCRIPTION
If you directly jump to the Important section that explains why allow entries are not user-configurable, but only via the submissions page, you might miss a direct pointer towards the right admin panel.

There are already several occurrences of where the URL added after mentioning the Submissions page in that page.

Idea: If you've already spent the time finding the reason as to why allow entries cannot be added by customers (by design), provide a direct link to the place one needs to do that.

Backstory: While the option to allow a URL in the Web UI is not available, attempting the same via Exchange Online Powershell using ``New-TenantAllowBlockListItems`` using the ``-Allow`` option leads to an error eventually lead me to the realization that it's not the GUI that is missing functionality, but that it is an actual design choice.