### PR TITLE
Update microsoft-defender-endpoint-linux.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/microsoft-defender-endpoint-linux.md
+++ b/microsoft-365/security/defender-endpoint/microsoft-defender-endpoint-linux.md
@@ -111,7 +111,7 @@ If you experience any installation failures, refer to [Troubleshooting installat
     - For 6.7: 2.6.32-573.* (except 2.6.32-573.el6.x86_64)
     - For 6.8: 2.6.32-642.*
     - For 6.9: 2.6.32-696.* (except 2.6.32-696.el6.x86_64)
-    - For 6.10: 2.6.32.754.2.1.el6.x86_64 to 2.6.32-754.48.1:
+    - For 6.10: 
       - 2.6.32-754.10.1.el6.x86_64
       - 2.6.32-754.11.1.el6.x86_64
       - 2.6.32-754.12.1.el6.x86_64


### PR DESCRIPTION
removed 2.6.32.754.2.1.el6.x86_64 to 2.6.32-754.48.1: 

as there are a few more versions added to the list

Fixes https://github.com/MicrosoftDocs/microsoft-365-docs/issues/12927