### PR TITLE
Updated reference to Microsoft Entra admin center

### DIFF
--- a/microsoft-365/admin/admin-overview/admin-center-overview.md
+++ b/microsoft-365/admin/admin-overview/admin-center-overview.md
@@ -5,7 +5,7 @@ f1.keywords:
 ms.author: efrene
 author: efrene
 manager: scotv
-ms.date: 08/10/2023
+ms.date: 10/23/2023
 audience: Admin
 ms.topic: article
 ms.service: microsoft-365-business
@@ -62,7 +62,7 @@ Here are the features and settings you'll find in the left-hand navigation of th
 |**Setup**|Manage existing domains, turn on and manage multi-factor authentication, manage admin access, migrate user mailboxes to Microsoft 365, manage feature updates, and help users install their Microsoft 365 apps.|
 |**Reports**|See at a glance how your organization is using Microsoft 365 with detailed reports on email use, Microsoft 365 activations, and more. Learn how to use the new [activity reports](../activity-reports/activity-reports.md).|
 |**Health**|View health at a glance. You can also check out more details and the health history. See [How to check service health](../../enterprise/view-service-health.md) and [How to check Windows release health](/windows/deployment/update/check-release-health) for more information. <p> Use Message center to keep track of upcoming changes to features and services. We post announcements there with information that helps you plan for change and understand how it may affect users. Get more details in [Message center](../manage/message-center.md).|
-|**Admin centers**|Open separate admin centers for Exchange, Skype for Business, SharePoint, Viva Engage, and Microsoft Entra ID. Each admin center includes all available settings for that service. <p> For example, in the Exchange admin center, set up and manage email, calendars, distribution groups, and more. In the SharePoint admin center, create and manage site collections, site settings, and OneDrive for Business. In the Skype for Business admin center, set up instant messaging notifications, dial-in conferencing, and online presence. <p> Learn more about the [Exchange admin center](/exchange/exchange-admin-center) and [SharePoint Admin Center](/sharepoint/sharepoint-online). <p> **Note:** The admin centers available to you depend on your plan and region.|
+|**Admin centers**|Open separate admin centers for Exchange, Skype for Business, SharePoint, Viva Engage, and Microsoft Entra. Each admin center includes all available settings for that service. <p> For example, in the Exchange admin center, set up and manage email, calendars, distribution groups, and more. In the SharePoint admin center, create and manage site collections, site settings, and OneDrive for Business. In the Skype for Business admin center, set up instant messaging notifications, dial-in conferencing, and online presence. <p> Learn more about the [Exchange admin center](/exchange/exchange-admin-center) and [SharePoint Admin Center](/sharepoint/sharepoint-online). <p> **Note:** The admin centers available to you depend on your plan and region.|
 
 ## Two dashboard views
 


### PR DESCRIPTION
Removed "ID" from "Microsoft Entra ID" as this particular line is referring to the admin centers and the one for IDNA is now called "Microsoft Entra admin center", expanded from what was just Azure AD to include configuration areas for other products under the Microsoft Entra product family.

<!--
Microsoft Entra rebrand: Please do not submit pull requests containing branding updates from Azure Active Directory, Azure AD, AAD, etc, to their respective Microsoft Entra equivalents at this time. 

Microsoft Entra rebranding is being coordinated across the Learn platform and will be applied to this repo automatically when we receive confirmation that product UIs have been updated. If you have questions regarding the rebrand project, contact dstrome.

This text can be deleted.
-->
