### PR TITLE
Typo Fix: Corrected 'masOS' to 'macOS'

### DIFF
--- a/microsoft-365/security/intelligence/malware-naming.md
+++ b/microsoft-365/security/intelligence/malware-naming.md
@@ -67,7 +67,7 @@ Describes what the malware does on your computer. Worms, viruses, trojans, backd
 ```
 ## Platforms
 
-Platforms guide the malware to its compatible operating system (such as Windows, masOS X, and Android). The platform's guidance is also used for programming languages and file formats.
+Platforms guide the malware to its compatible operating system (such as Windows, macOS, and Android). The platform's guidance is also used for programming languages and file formats.
 
 ### Operating systems
 ```


### PR DESCRIPTION
In this pull request, I've corrected a typo on the page regarding malware naming. The typo was in the word "masOS," which should be "macOS." It's worth noting that Apple has transitioned from "Mac OS X" to simply "macOS" without the "X" in their naming convention. This change improves the accuracy and readability of the documentation. Please review and merge this pull request. Thank you!


