### PR TITLE
Update attack-simulation-training-simulation-automations.md

### DIFF
--- a/microsoft-365/security/office-365-security/attack-simulation-training-simulation-automations.md
+++ b/microsoft-365/security/office-365-security/attack-simulation-training-simulation-automations.md
@@ -210,9 +210,6 @@ On the **Target users** page, select who receives the simulation. Use the follow
 
 - **Include all users in your organization**: The unmodifiable list of users is show in groups of 10. You can use the **Next** and **Previous** buttons directly below the list of users to scroll through the list. You can also use the :::image type="icon" source="../../media/m365-cc-sc-search-icon.png" border="false"::: **Search** icon on the page to find specific users.
 
-  > [!TIP]
-  > Although you can't remove users from the list on this page, you can use the next **Exclude users** page to exclude specific users.
-
 - **Include only specific users and groups**: At first, no users or groups are shown on the **Targeted users** page. To add users or groups to the simulation, choose one of the following options:
 
   - :::image type="icon" source="../../media/m365-cc-sc-create-icon.png" border="false"::: **Add users**: In the **Add users** flyout that opens, you find and select users and groups to receive the simulation. **Dynamic distribution groups are not supported**. The following search tools are available:


### PR DESCRIPTION
Excluding users from target users list is not available in simulation automation. Therefore, removed it from the documentation. cc: @chrisda 
