### PR TITLE
Update contact-support.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/contact-support.md
+++ b/microsoft-365/security/defender-endpoint/contact-support.md
@@ -45,7 +45,7 @@ It's important to know the specific roles that have permission to open support c
 
 At a minimum, you must have a Service Support Administrator **OR** Helpdesk Administrator role.
 
-For more information on which roles have permission, see, [Security Administrator permissions](/azure/active-directory/roles/permissions-reference#security-administrator). 
+For more information on which roles have permission, see [Security Administrator permissions](/azure/active-directory/roles/permissions-reference#security-administrator). 
 
 For general information on admin roles, see [About admin roles](/microsoft-365/admin/add-users/about-admin-roles?view=o365-worldwide&preserve-view=true).
 

--- a/microsoft-365/security/defender-endpoint/contact-support.md
+++ b/microsoft-365/security/defender-endpoint/contact-support.md
@@ -45,7 +45,7 @@ It's important to know the specific roles that have permission to open support c
 
 At a minimum, you must have a Service Support Administrator **OR** Helpdesk Administrator role.
 
-For more information on which roles have permission, see, [Security Administrator permissions](/azure/active-directory/roles/permissions-reference#security-administrator). Roles that include the action `microsoft.office365.supportTickets/allEntities/allTasks` can submit a case.
+For more information on which roles have permission, see, [Security Administrator permissions](/azure/active-directory/roles/permissions-reference#security-administrator). 
 
 For general information on admin roles, see [About admin roles](/microsoft-365/admin/add-users/about-admin-roles?view=o365-worldwide&preserve-view=true).
 


### PR DESCRIPTION
removed Roles that include the action `microsoft.office365.supportTickets/allEntities/allTasks` can submit a case. as only Service Support Administrator OR Helpdesk Administrator roles are able to open support cases 

Fixes https://github.com/MicrosoftDocs/microsoft-365-docs/issues/13192


