### PR TITLE
Updating the Linux kernel version required by ebpf sensor in MDATP

### DIFF
--- a/microsoft-365/security/defender-endpoint/linux-support-ebpf.md
+++ b/microsoft-365/security/defender-endpoint/linux-support-ebpf.md
@@ -54,9 +54,9 @@ The eBPF sensor for Microsoft Defender for Endpoint on Linux is supported on the
 |--------------------|----------------------|----------------|
 | Ubuntu             | 16.04                | 4.15.0         |
 | Fedora             | 33                   | 5.8.15         |
-| CentOS             | 7.6                  | 3.10.0-957     |
+| CentOS             | 7.6                  | 3.10.0-957.12  |
 | SLES               | 15                   | 5.3.18-18.47   |
-| RHEL               | 7.6                  | 3.10.0-957     |
+| RHEL               | 7.6                  | 3.10.0-957.12  |
 | Debian             | 9.0                  | 4.19.0         |
 | Oracle Linux RHCK  | 7.9                  | 3.10.0-1160    |
 | Oracle Linux UEK   | 7.9                  | 5.4            |

--- a/microsoft-365/security/defender-endpoint/linux-support-ebpf.md
+++ b/microsoft-365/security/defender-endpoint/linux-support-ebpf.md
@@ -14,7 +14,7 @@ ms.collection:
 ms.topic: conceptual
 ms.subservice: linux
 search.appverid: met150
-ms.date: 11/17/2023
+ms.date: 12/11/2023
 ---
 
 # Use eBPF-based sensor for Microsoft Defender for Endpoint on Linux


### PR DESCRIPTION
With this PR I have tried to update the kernel version requirement for the EBPF-based sensor in Microsoft Defender documentation. The revised kernel version for Red Hat Enterprise Linux (RHEL) and CentOS is now specified as 3.10.0-957.12


