### PR TITLE
Update microsoft-365-copilot-requirements.md

### DIFF
--- a/copilot/microsoft-365-copilot-requirements.md
+++ b/copilot/microsoft-365-copilot-requirements.md
@@ -48,7 +48,7 @@ Some features in Microsoft Copilot for Microsoft 365, such as file restore and O
 
 Microsoft Copilot for Microsoft 365 works with the new Outlook (for [Windows](https://support.microsoft.com/office/getting-started-with-the-new-outlook-for-windows-656bb8d9-5a60-49b2-a98b-ba7822bc7627) and [Mac](https://support.microsoft.com/office/the-new-outlook-for-mac-6283be54-e74d-434e-babb-b70cefc77439)), which are currently in preview. Users can switch to the new Outlook by selecting **Try the new Outlook** in their existing Outlook client.
 
-To have Copilot appear in the new Outlook, you need to sync your Microsoft 365 settings. To do this, go to [View and manage your Microsoft 365 settings](https://myaccount.microsoft.com/settingsandprivacy/language).
+To have Copilot appear in the new Outlook, you need to sync your Microsoft 365 settings. To do this, go to [View and manage your Microsoft 365 settings](https://myaccount.microsoft.com/settingsandprivacy/language). If the Copilot icon does not appear in the new Outlook, try changing the Display language of your Microsoft 365 to one of the languages supported by Microsoft Copilot for Microsoft 365.
 
 Microsoft Copilot for Microsoft 365 will be supported on classic Outlook for Windows (Win32 desktop app) in the future. You can [review the roadmap item here](https://www.microsoft.com/microsoft-365/roadmap?rtc=1&filters=Outlook&searchterms=copilot).
 


### PR DESCRIPTION
When running the new Outlook desktop app in a language that is currently not in the list of supported languages of Microsoft Copilot for Microsoft 365, the Microsoft Copilot icon will not be displayed. Changing the Display language of Microsoft 365 to a supported language, like English, will resolve this issue.  To reduce the likelihood of support cases, the Copilot for Microsoft 365 documentation should include this information.


