### PR TITLE
Update manage-creation-of-groups.md

### DIFF
--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -2,8 +2,8 @@
 title: Manage who can create Microsoft 365 Groups
 f1.keywords: NOCSH
 ms.author: mikeplum
-ms.reviewer: rahulnayak
-ms.date: 11/22/2023
+ms.reviewer: dntt3:lQ
+ms.date: 18/03/2024
 author: MikePlumleyMSFT
 manager: pamgreen
 audience: Admin
@@ -123,12 +123,6 @@ if(!$settingsObjectID)
 {
     $params = @{
 	  templateId = "62375ab9-6b52-47ed-826b-58e47e0e304b"
-	  values = @(
-		    @{
-			       name = "EnableMSStandardBlockedWords"
-			       value = "true"
-		     }
-	 	     )
 	     }
 	
     New-MgBetaDirectorySetting -BodyParameter $params
@@ -136,8 +130,8 @@ if(!$settingsObjectID)
     $settingsObjectID = (Get-MgBetaDirectorySetting | Where-object -Property Displayname -Value "Group.Unified" -EQ).Id
 }
 
- 
-$groupId = (Get-MgBetaGroup | Where-object {$_.displayname -eq $GroupName}).Id
+$groups = Get-MgBetaGroup -All
+$groupId = ( $groups | Where-object {$_.displayname -eq $GroupName}).Id
 
 $params = @{
 	templateId = "62375ab9-6b52-47ed-826b-58e47e0e304b"

--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -3,7 +3,7 @@ title: Manage who can create Microsoft 365 Groups
 f1.keywords: NOCSH
 ms.author: mikeplum
 ms.reviewer: dntt3:lQ
-ms.date: 18/03/2024
+ms.date: 03/18/2024
 author: MikePlumleyMSFT
 manager: pamgreen
 audience: Admin

--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -2,8 +2,8 @@
 title: Manage who can create Microsoft 365 Groups
 f1.keywords: NOCSH
 ms.author: mikeplum
-ms.reviewer: dntt3:lQ
-ms.date: 03/18/2024
+ms.reviewer: rahulnayak
+ms.date: 11/22/2023
 author: MikePlumleyMSFT
 manager: pamgreen
 audience: Admin


### PR DESCRIPTION
Made some changes adding "-All" parameter to the Get-MgBetaGroup cmdlet, in order to retrieve all groups to ensure the capability to read over 100 elements in group lists. Also, I deleted the entire hash table that contains the 'EnableMSStandardBlockedWords' function since it is deprecated and retired. I only left the templateId.


