### PR TITLE
Added information about Mac Device Control and Sonoma

### DIFF
--- a/microsoft-365/security/defender-endpoint/mac-device-control-overview.md
+++ b/microsoft-365/security/defender-endpoint/mac-device-control-overview.md
@@ -101,6 +101,9 @@ Here are the properties you can use when you create the group and policy.
 > 
 > You can also use the scripts at [mdatp-devicecontrol/Removable Storage Access Control Samples/macOS/policy/scripts at main - microsoft/mdatp-devicecontrol (github.com)](https://github.com/microsoft/mdatp-devicecontrol/tree/main/Removable%20Storage%20Access%20Control%20Samples/macOS/policy/scripts) to translate Windows Device Control policy to macOS Device Control policy or translate macOS Device Control V1 policy to this V2 policy.
 
+>[!WARNING]
+>In MacOS Sonoma 14.3.1, Apple made a change to the [handling of Bluetooth devices](https://developer.apple.com/forums/thread/738748) devices that impacted MDE device controls ability to intercept and block access to Bluetooth devices.  At this time, the recommended mitigation is to use a version of MacOS less than 14.3.1.
+
 ### Settings
 
 | Property name | Description | Options |

--- a/microsoft-365/security/defender-endpoint/mac-device-control-overview.md
+++ b/microsoft-365/security/defender-endpoint/mac-device-control-overview.md
@@ -102,7 +102,7 @@ Here are the properties you can use when you create the group and policy.
 > You can also use the scripts at [mdatp-devicecontrol/Removable Storage Access Control Samples/macOS/policy/scripts at main - microsoft/mdatp-devicecontrol (github.com)](https://github.com/microsoft/mdatp-devicecontrol/tree/main/Removable%20Storage%20Access%20Control%20Samples/macOS/policy/scripts) to translate Windows Device Control policy to macOS Device Control policy or translate macOS Device Control V1 policy to this V2 policy.
 
 >[!WARNING]
->In MacOS Sonoma 14.3.1, Apple made a change to the [handling of Bluetooth devices](https://developer.apple.com/forums/thread/738748) devices that impacted MDE device controls ability to intercept and block access to Bluetooth devices.  At this time, the recommended mitigation is to use a version of MacOS less than 14.3.1.
+>In macOS Sonoma 14.3.1, Apple made a change to the [handling of Bluetooth devices](https://developer.apple.com/forums/thread/738748) that impacts Defender for Endpoint device controls ability to intercept and block access to Bluetooth devices.  At this time, the recommended mitigation is to use a version of macOS less than 14.3.1.
 
 ### Settings
 

--- a/microsoft-365/security/defender-endpoint/mac-whatsnew.md
+++ b/microsoft-365/security/defender-endpoint/mac-whatsnew.md
@@ -56,7 +56,8 @@ Network protection for macOS is now available for all Mac devices onboarded to D
 
 Apple fixed an issue on macOS [Ventura upgrade](<https://developer.apple.com/documentation/macos-release-notes/macos-13_1-release-notes>), which is fixed with the latest OS update. The issue impacts Microsoft Defender for Endpoint security extensions, and might result in losing Full Disk Access Authorization, impacting its ability to function properly.
 
-In MacOS Sonoma 14.3.1, Apple made a change to the [handling of Bluetooth devices](https://developer.apple.com/forums/thread/738748) devices that impacted MDE device controls ability to intercept and block access to Bluetooth devices.  At this time, the recommended mitigation is to use a version of MacOS less than 14.3.1.
+In macOS Sonoma 14.3.1, Apple made a change to the [handling of Bluetooth devices](https://developer.apple.com/forums/thread/738748) that impacts Defender for Endpoint device controls ability to intercept and block access to Bluetooth devices.  At this time, the recommended mitigation is to use a version of macOS less than 14.3.1.
+
 
 **Sonoma support**
 

--- a/microsoft-365/security/defender-endpoint/mac-whatsnew.md
+++ b/microsoft-365/security/defender-endpoint/mac-whatsnew.md
@@ -56,6 +56,8 @@ Network protection for macOS is now available for all Mac devices onboarded to D
 
 Apple fixed an issue on macOS [Ventura upgrade](<https://developer.apple.com/documentation/macos-release-notes/macos-13_1-release-notes>), which is fixed with the latest OS update. The issue impacts Microsoft Defender for Endpoint security extensions, and might result in losing Full Disk Access Authorization, impacting its ability to function properly.
 
+In MacOS Sonoma 14.3.1, Apple made a change to the [handling of Bluetooth devices](https://developer.apple.com/forums/thread/738748) devices that impacted MDE device controls ability to intercept and block access to Bluetooth devices.  At this time, the recommended mitigation is to use a version of MacOS less than 14.3.1.
+
 **Sonoma support**
 
 Microsoft Defender supports macOS Sonoma (14.0) in the current Defender release.


### PR DESCRIPTION
In MacOS Sonoma 14.3.1, Apple made a change to the [handling of Bluetooth devices](https://developer.apple.com/forums/thread/738748) devices that impacted MDE device controls ability to intercept and block access to Bluetooth devices.  At this time, the recommended mitigation is to use a version of MacOS less than 14.3.1.

This information is added to appropriate places in MAC Device Control documentation