### PR TITLE
Update esignature-setup.md

### DIFF
--- a/microsoft-365/syntex/esignature-setup.md
+++ b/microsoft-365/syntex/esignature-setup.md
@@ -36,7 +36,7 @@ You must have Global admin or SharePoint admin permissions to be able to access 
 
 ### External recipients
 
- If you will be requesting signatures from external recipients, you need to enable [Microsoft Entra B2B integration for SharePoint and OneDrive](/sharepoint/sharepoint-azureb2b-integration#enabling-the-integration) and guest sharing [Collaboration with guests in a site]https://learn.microsoft.com/en-us/microsoft-365/solutions/collaborate-in-site?view=o365-worldwide). External recipients are people outside your organization and would be onboarded as guests into your tenant. Microsoft Entra B2B provides authentication and management of guests.
+ If you will be requesting signatures from external recipients, you need to enable [Microsoft Entra B2B integration for SharePoint and OneDrive](/sharepoint/sharepoint-azureb2b-integration#enabling-the-integration) and [guest sharing](/microsoft-365/solutions/collaborate-in-site). External recipients are people outside your organization and would be onboarded as guests into your tenant. Microsoft Entra B2B provides authentication and management of guests.
 
 ## Set up SharePoint eSignature
 

--- a/microsoft-365/syntex/esignature-setup.md
+++ b/microsoft-365/syntex/esignature-setup.md
@@ -88,7 +88,7 @@ Microsoft Entra B2B provides authentication and management of guests. External s
 
 ### Authentication
 
-External recipients might need to authenticate before they're able to access a document for signing. The type of authentication required by the external recipients depends on the configuration for guest users at the SharePoint level or at the tenant level. Additionally, if the external user belongs to an organization with a Microsoft 365 tenant, it's possible for their organization's setup to affect their authentication experience when attempting to sign the document. More details can be found: [Collaboration with guests in a site]https://learn.microsoft.com/en-us/microsoft-365/solutions/collaborate-in-site?view=o365-worldwide)
+External recipients might need to authenticate before they're able to access a document for signing. The type of authentication required by the external recipients depends on the configuration for guest users at the SharePoint level or at the tenant level. Additionally, if the external user belongs to an organization with a Microsoft 365 tenant, it's possible for their organization's setup to affect their authentication experience when attempting to sign the document. For more information, see [Collaboration with guests in a site](/microsoft-365/solutions/collaborate-in-site).
 
 ## Document storage and retention
 

--- a/microsoft-365/syntex/esignature-setup.md
+++ b/microsoft-365/syntex/esignature-setup.md
@@ -36,7 +36,7 @@ You must have Global admin or SharePoint admin permissions to be able to access 
 
 ### External recipients
 
- If you will be requesting signatures from external recipients, you need to enable [Microsoft Entra B2B integration for SharePoint and OneDrive](/sharepoint/sharepoint-azureb2b-integration#enabling-the-integration). External recipients are people outside your organization and would be onboarded as guests into your tenant. Microsoft Entra B2B provides authentication and management of guests. SharePoint eSignature can be used for internal signatures only. In this case, this setting doesn't need to be enabled.
+ If you will be requesting signatures from external recipients, you need to enable [Microsoft Entra B2B integration for SharePoint and OneDrive](/sharepoint/sharepoint-azureb2b-integration#enabling-the-integration) and guest sharing [Collaboration with guests in a site]https://learn.microsoft.com/en-us/microsoft-365/solutions/collaborate-in-site?view=o365-worldwide). External recipients are people outside your organization and would be onboarded as guests into your tenant. Microsoft Entra B2B provides authentication and management of guests.
 
 ## Set up SharePoint eSignature
 
@@ -88,7 +88,7 @@ Microsoft Entra B2B provides authentication and management of guests. External s
 
 ### Authentication
 
-External recipients might need to authenticate before they're able to access a document for signing. The type of authentication required by the external recipients depends on the configuration for guest users at the SharePoint level or at the tenant level. Additionally, if the external user belongs to an organization with a Microsoft 365 tenant, it's possible for their organization's setup to affect their authentication experience when attempting to sign the document.
+External recipients might need to authenticate before they're able to access a document for signing. The type of authentication required by the external recipients depends on the configuration for guest users at the SharePoint level or at the tenant level. Additionally, if the external user belongs to an organization with a Microsoft 365 tenant, it's possible for their organization's setup to affect their authentication experience when attempting to sign the document. More details can be found: [Collaboration with guests in a site]https://learn.microsoft.com/en-us/microsoft-365/solutions/collaborate-in-site?view=o365-worldwide)
 
 ## Document storage and retention
 


### PR DESCRIPTION
Added links to guest sharing both in the Prerequisites/External recipients section and the Authentication section below.   These should both align though we should discuss the fact that the content is duplicated.
I'm not sure the links were currently marked up.  The text should be 'Collaborate with guests in a site' and it should point to here https://learn.microsoft.com/en-us/microsoft-365/solutions/collaborate-in-site?view=o365-worldwide in both cases.


