### PR TITLE
Update comprehensive-guidance-on-linux-deployment.md

### DIFF
--- a/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -103,7 +103,7 @@ Use the following steps to check the network connectivity of Microsoft Defender 
 3. Verify that the traffic isn't being inspected by SSL inspection (TLS inspection). This is the most common network related issue when setting up Microsoft Defender Endpoint, see [Verify SSL inspection isn't being performed on the network traffic](#step-3-verify-ssl-inspection-isnt-being-performed-on-the-network-traffic).
 
 > [!NOTE]
-> The consideration in item#3 is a general consideration for Defender for Endpoint across all supported operating systems (Windows, Linux, and MacOS)
+> The consideration in item#3 is a general consideration for Defender for Endpoint across all supported operating systems (Windows, Linux, and MacOS).
 
 #### Step 1: Allow URLs for the Microsoft Defender for Endpoint traffic
 

--- a/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -103,7 +103,7 @@ Use the following steps to check the network connectivity of Microsoft Defender 
 3. Verify that the traffic isn't being inspected by SSL inspection (TLS inspection). This is the most common network related issue when setting up Microsoft Defender Endpoint, see [Verify SSL inspection isn't being performed on the network traffic](#step-3-verify-ssl-inspection-isnt-being-performed-on-the-network-traffic).
 
 > [!NOTE]
-> The consideration in item#3 is a general consideration for Defender for Endpoint across all supported operating systems (Windows, Linux, and MacOS).
+> It's generally recommended that traffic isn't inspected by SSL inspection (TLS inspection) for Defender for Endpoint across all supported operating systems (Windows, Linux, and MacOS).
 
 #### Step 1: Allow URLs for the Microsoft Defender for Endpoint traffic
 

--- a/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -101,7 +101,9 @@ Use the following steps to check the network connectivity of Microsoft Defender 
 2. If the Linux servers are behind a proxy, then set the proxy settings. For more information, see [Set up proxy settings](#step-2-set-up-proxy-settings).
 
 3. Verify that the traffic isn't being inspected by SSL inspection (TLS inspection). This is the most common network related issue when setting up Microsoft Defender Endpoint, see [Verify SSL inspection isn't being performed on the network traffic](#step-3-verify-ssl-inspection-isnt-being-performed-on-the-network-traffic).
-NOTE: The consideration in item#3 is a general consideration for Defender for Endpoint across all supported operating systems, Windows, Linux and MacOS
+
+> [!NOTE]
+> The consideration in item#3 is a general consideration for Defender for Endpoint across all supported operating systems (Windows, Linux, and MacOS)
 
 #### Step 1: Allow URLs for the Microsoft Defender for Endpoint traffic
 

--- a/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -101,6 +101,7 @@ Use the following steps to check the network connectivity of Microsoft Defender 
 2. If the Linux servers are behind a proxy, then set the proxy settings. For more information, see [Set up proxy settings](#step-2-set-up-proxy-settings).
 
 3. Verify that the traffic isn't being inspected by SSL inspection (TLS inspection). This is the most common network related issue when setting up Microsoft Defender Endpoint, see [Verify SSL inspection isn't being performed on the network traffic](#step-3-verify-ssl-inspection-isnt-being-performed-on-the-network-traffic).
+NOTE: The consideration in item#3 is a general consideration for Defender for Endpoint across all supported operating systems, Windows, Linux and MacOS
 
 #### Step 1: Allow URLs for the Microsoft Defender for Endpoint traffic
 

--- a/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
+++ b/microsoft-365/security/defender-endpoint/comprehensive-guidance-on-linux-deployment.md
@@ -103,7 +103,7 @@ Use the following steps to check the network connectivity of Microsoft Defender 
 3. Verify that the traffic isn't being inspected by SSL inspection (TLS inspection). This is the most common network related issue when setting up Microsoft Defender Endpoint, see [Verify SSL inspection isn't being performed on the network traffic](#step-3-verify-ssl-inspection-isnt-being-performed-on-the-network-traffic).
 
 > [!NOTE]
-> It's generally recommended that traffic isn't inspected by SSL inspection (TLS inspection) for Defender for Endpoint across all supported operating systems (Windows, Linux, and MacOS).
+> It is generally recommended that traffic for Defender for Endpoint is not inspected by SSL inspection (TLS inspection). This applies to all supported operating systems (Windows, Linux, and MacOS).
 
 #### Step 1: Allow URLs for the Microsoft Defender for Endpoint traffic
 


### PR DESCRIPTION
I confirmed internally that the consideration to avoid inspecting SSL traffic for Defender for Endpoint mentioned here in the Linux article, it is a consideration for all supported OS, Windows, Linux and MacOS. I thought of adding a note to the article to make it clear for customers.
If the note can be highlighted with the purple-ish color we use for notes, that'll be great. Is that something I need to do?


