### PR TITLE
removed MacOS and Linux compatiblity for the PUA test scenario

### DIFF
--- a/microsoft-365/security/defender-endpoint/defender-endpoint-demonstration-potentially-unwanted-applications.md
+++ b/microsoft-365/security/defender-endpoint/defender-endpoint-demonstration-potentially-unwanted-applications.md
@@ -33,8 +33,6 @@ The Potentially Unwanted Applications (PUA) protection feature in Microsoft Defe
 
 - Windows 11 or Windows 10
 - Windows Server 2022, Windows Server 2019, Windows Server 2016, Windows Server 2012 R2, and Windows Server 2008 R2 SP1
-- macOS
-- Linux
 - Enable PUA protection. For more information, see the [Detect and block Potentially Unwanted Applications](detect-block-potentially-unwanted-apps-microsoft-defender-antivirus.md) article.
 - You can also [download and use the PowerShell script](https://www.powershellgallery.com/packages/WindowsDefender_InternalEvaluationSettings/) to enable this setting and others.
 


### PR DESCRIPTION
The amtso.org URL refers to a .exe file, which is not runnable on Linux and MacOS and therefore can't be used as a way to trigger PUA alerts on these operating systems.


