### PR TITLE
Update office-365-operated-by-21vianet-endpoints.md

### DIFF
--- a/microsoft-365/includes/office-365-operated-by-21vianet-endpoints.md
+++ b/microsoft-365/includes/office-365-operated-by-21vianet-endpoints.md
@@ -36,7 +36,7 @@ ID | Category | ER | Addresses | Ports
 10 | Allow<BR>Required | No | `*.partner.microsoftonline.cn`<BR>`103.9.8.0/22` | **TCP:** 443, 80
 11 | Default<BR>Required | No | `activation.sls.microsoft.com, crl.microsoft.com, odc.officeapps.live.com, officecdn.microsoft.com, officeclient.microsoft.com` | **TCP:** 443, 80
 13 | Default<BR>Required | No | `*.msauth.cn, *.msauthimages.cn, *.msftauth.cn, *.msftauthimages.cn, login.microsoftonline.com` | **TCP:** 443, 80
-15 | Default<BR>Required | No | `loki.office365.cn` | **TCP:** 443
+15 | Default<BR>Required | No | `loki.office365.cn`,`partner.outlook.cn` | **TCP:** 443
 16 | Default<BR>Required | No | `*.cdn.office.net, shellprod.msocdn.com` | **TCP:** 443
 17 | Allow<BR>Required | No | `*.auth.microsoft.cn, login.partner.microsoftonline.cn, microsoftgraph.chinacloudapi.cn`<BR>`40.72.70.0/23, 52.130.2.32/27, 52.130.3.64/27, 52.130.17.192/27, 52.130.18.32/27, 2406:e500:5500::/48` | **TCP:** 443, 80
 18 | Default<BR>Optional<BR>**Notes:** If using Exchange Online, follow Allow category guidance for *.protection.partner.outlook.cn | No | `*.aadrm.cn, *.protection.partner.outlook.cn` | **TCP:** 443

--- a/microsoft-365/includes/office-365-operated-by-21vianet-endpoints.md
+++ b/microsoft-365/includes/office-365-operated-by-21vianet-endpoints.md
@@ -36,7 +36,7 @@ ID | Category | ER | Addresses | Ports
 10 | Allow<BR>Required | No | `*.partner.microsoftonline.cn`<BR>`103.9.8.0/22` | **TCP:** 443, 80
 11 | Default<BR>Required | No | `activation.sls.microsoft.com, crl.microsoft.com, odc.officeapps.live.com, officecdn.microsoft.com, officeclient.microsoft.com` | **TCP:** 443, 80
 13 | Default<BR>Required | No | `*.msauth.cn, *.msauthimages.cn, *.msftauth.cn, *.msftauthimages.cn, login.microsoftonline.com` | **TCP:** 443, 80
-15 | Default<BR>Required | No | `loki.office365.cn`,`partner.outlook.cn` | **TCP:** 443
+15 | Default<BR>Required | No | `loki.office365.cn, partner.outlook.cn` | **TCP:** 443
 16 | Default<BR>Required | No | `*.cdn.office.net, shellprod.msocdn.com` | **TCP:** 443
 17 | Allow<BR>Required | No | `*.auth.microsoft.cn, login.partner.microsoftonline.cn, microsoftgraph.chinacloudapi.cn`<BR>`40.72.70.0/23, 52.130.2.32/27, 52.130.3.64/27, 52.130.17.192/27, 52.130.18.32/27, 2406:e500:5500::/48` | **TCP:** 443, 80
 18 | Default<BR>Optional<BR>**Notes:** If using Exchange Online, follow Allow category guidance for *.protection.partner.outlook.cn | No | `*.aadrm.cn, *.protection.partner.outlook.cn` | **TCP:** 443


### PR DESCRIPTION
According to https://learn.microsoft.com/en-au/microsoft-365/enterprise/managing-office-365-endpoints?view=o365-21vianet#i-have-to-have-the-minimum-connectivity-possible-for-microsoft-365 “The Microsoft 365 suite is broken down into major service areas. These areas can be selectively enabled for connectivity and there's a Common area, which is a dependency for all and is always required.”

All URLs and IP address whitelist for SPO should be covered in https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges-21vianet?view=o365-worldwide#sharepoint-online-and-onedrive-for-business and 
https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges-21vianet?view=o365-worldwide#microsoft-365-common-and-office-online.

For SPO in 21Vianet, the search has been migrated to substrate search<partner.outlook.cn>; so SPO search dependency substrate URL <partner.outlook.cn> should be added to <Microsoft 365 Common and Office Online> section.

21Vianet SPO Search Demo:
https://partner.outlook.cn/search/api/v2/query?setflight=EnableServerSideWholePageRelevance&msgRequestId=ce7dcd41-d024-4de3-b17c-5f3b6e89de4a


