### PR TITLE
Update turn-bookings-on-or-off.md

### DIFF
--- a/microsoft-365/bookings/turn-bookings-on-or-off.md
+++ b/microsoft-365/bookings/turn-bookings-on-or-off.md
@@ -139,7 +139,7 @@ You'll need to run the following commands using Exchange Online PowerShell. For 
 
    For more information, see [Set-CASMailbox](/powershell/module/exchange/set-casmailbox).
 
-3. Optional: Run this command if you want to disable Bookings for all other users in your organization.
+3. Optional: Run this command if you want to disable creation of booking calendars for all other users in your organization.
 
    ```PowerShell
    Set-OwaMailboxPolicy "OwaMailboxPolicy-Default" -BookingsMailboxCreationEnabled:$false


### PR DESCRIPTION
"Optional: Run this command if you want to disable Bookings for all other users in your organization."  This makes the documentation sound like configuring the OWA Mailbox Policy allows for granular control of Bookings with Me, but it does not.  Corrected step 3 to clarify that this only affects the ability to create bookings calendars.


