### PR TITLE
Updated ABT Activation and FAQ Sections

### DIFF
--- a/microsoft-365/admin/manage/idle-session-timeout-web-apps.md
+++ b/microsoft-365/admin/manage/idle-session-timeout-web-apps.md
@@ -141,7 +141,7 @@ If you're working on a different web app with the same account, the activity in 
 
 Azure portal supports a similar inactivity feature, but is supported by Azure portal only. 
 
-Note - Upon initial activation within Azure Portal, the timeout duration is initally inherited from M365 Idle Session Timeout. Azure portal timeout policy can be set explicity within the Azure Portal.  For more information, see [Azure portal: Signing-Out + Notification](/azure/azure-portal/set-preferences#signing-out--notifications).
+Note - When initially activated within the Azure Portal, the timeout duration by default inherits from M365 Admin Center Idle Session Timeout Setting. However, the timeout policy for the Azure Portal can be explicitly configured within the portal itself.  For more information, see [Azure portal: Signing-Out + Notification](/azure/azure-portal/set-preferences#signing-out--notifications).
 
 ### I want to make changes to the idle session timeout policy or delete it. How can I do that?
 

--- a/microsoft-365/admin/manage/idle-session-timeout-web-apps.md
+++ b/microsoft-365/admin/manage/idle-session-timeout-web-apps.md
@@ -31,7 +31,7 @@ When a user reaches the idle timeout session you've set, they'll get a notificat
 
 ## Turn on Idle session timeout
 
-You must be a member of the Global admin, Security admin, Application admin, or Cloud Application admin roles to see the idle session timeout setting.
+You must be a member of the Global admin, Security admin, Application admin, or Cloud Application admin roles to see the idle session timeout setting.  The Global admin role is required for initial activation of Idle Session Timeout.  All other noted roles can deactivate and/or modify timeout duration settings. 
 
 1. In the Microsoft 365 admin center, select **Org Settings** **->**  [Security & privacy](https://go.microsoft.com/fwlink/p/?linkid=2072756) tab and select **Idle session timeout**.
 
@@ -139,7 +139,9 @@ If you're working on a different web app with the same account, the activity in 
 
 ### I'm active in Azure portal, but I'm logged out of other M365 Apps for inactivity.  Why am I logged out?
 
-Azure portal supports a similar inactivity feature, but is supported by Azure portal only. For more information, see [Azure portal: Signing-Out + Notification](/azure/azure-portal/set-preferences#signing-out--notifications).
+Azure portal supports a similar inactivity feature, but is supported by Azure portal only. 
+
+Note - Upon initial activation within Azure Portal, the timeout duration is initally inherited from M365 Idle Session Timeout. Azure portal timeout policy can be set explicity within the Azure Portal.  For more information, see [Azure portal: Signing-Out + Notification](/azure/azure-portal/set-preferences#signing-out--notifications).
 
 ### I want to make changes to the idle session timeout policy or delete it. How can I do that?
 


### PR DESCRIPTION
1. Added additional detail regarding which roles are required for initial activation of Idle Session Timeout.
2. Added additional note to FAQ for Azure Portal timeout inheritance from M365.


