### PR TITLE
Update manage-creation-of-groups.md

### DIFF
--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -137,7 +137,7 @@ if(!$settingsObjectID)
 }
 
  
-$groupId = (Get-MgBetaGroup | Where-object {$_.displayname -eq $GroupName}).Id
+$groupId = (Get-MgBetaGroup -All | Where-object {$_.displayname -eq $GroupName}).Id
 
 $params = @{
 	templateId = "62375ab9-6b52-47ed-826b-58e47e0e304b"


### PR DESCRIPTION
Added the '-All' flag to the 'Get-MgBetaGroup' command on line 140 of this file.

'Get-MgBetaGroup' only returns the first 100 results. This means the script does not work properly in environments with over 100 groups.

Adding the '-All' flag to 'Get-MgBetaGroup' allows the command to return all results, allowing the script to work properly in environments with a large volume of groups.


