### PR TITLE
Update microsoft-365-groups-expiration-policy.md

### DIFF
--- a/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
+++ b/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
@@ -52,6 +52,7 @@ It's important to know that expiration is turned off by default. Administrators 
 |Role|What they can do|
 |---------|---------|
 |Office 365 global admin (in Azure, the Company administrator), User administrator|Create, read, update, or delete the Microsoft 365 groups expiration policy settings.|
+|Groups Administrator|Members of this role can create/manage groups, create/manage groups settings like naming and expiration policies, and view groups activity and audit reports.|
 |User|Renew or [restore](/azure/active-directory/users-groups-roles/groups-restore-deleted) a Microsoft 365 group that they own|
 
 > [!IMPORTANT]

--- a/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
+++ b/microsoft-365/solutions/microsoft-365-groups-expiration-policy.md
@@ -1,7 +1,7 @@
 ---
 title: "Microsoft 365 group expiration policy"
 ms.reviewer: rahulnayak
-ms.date: 08/12/2020
+ms.date: 06/25/2024
 f1.keywords: NOCSH
 ms.author: jtremper
 author: jacktremper


### PR DESCRIPTION
adding the groups administrator role to the "Who can configure and use the Microsoft 365 groups expiration policy?" section


