### PR TITLE
Update microsoft-365-copilot-requirements.md for O365 license activation

### DIFF
--- a/copilot/microsoft-365-copilot-requirements.md
+++ b/copilot/microsoft-365-copilot-requirements.md
@@ -36,7 +36,7 @@ The following are the prerequisites for using Microsoft Copilot for Microsoft 36
 > [!NOTE]
 > - For Copilot to work in Word Online, Excel Online, and PowerPoint Online, you need to have third-party cookies enabled.
 > - Review your privacy settings for Microsoft 365 Apps because those settings might have an effect on the availability of Microsoft Copilot for Microsoft 365 features. For more information, see [Microsoft Copilot for Microsoft 365 and policy settings for connected experiences](microsoft-365-copilot-privacy.md#microsoft-copilot-for-microsoft-365-and-policy-settings-for-connected-experiences).
-> - Copilot is not available on Device-Based Licensing for Office 365 Apps.
+> - Copilot is not available on Device-Based Licensing and Shared Computer Activation for Office 365 Apps.
 
 ### Microsoft Entra ID
 


### PR DESCRIPTION
Added Shared Computer Activation limitation for Copilot enablement on devices.
When registry key "SharedComputerLicensing" is set to "1", Copilot won't enable. Removing registry key fixes the issue.


