### PR TITLE
Update manage-creation-of-groups.md

### DIFF
--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -137,7 +137,7 @@ if(!$settingsObjectID)
 }
 
  
-$groupId = (Get-MgBetaGroup | Where-object {$_.displayname -eq $GroupName}).Id
+$groupId = (Get-MgBetaGroup -All | Where-object {$_.displayname -eq $GroupName}).Id
 
 $params = @{
 	templateId = "62375ab9-6b52-47ed-826b-58e47e0e304b"


### PR DESCRIPTION
Added -All to Get-MgBetaGroup which resolves an issue with the script failing to assign a group ID due to limitations of failing to load the full list of groups from Entra.


