### PR TITLE
Update use-the-centralized-deployment-powershell-cmdlets-to-manage-ad…

### DIFF
--- a/microsoft-365/enterprise/use-the-centralized-deployment-powershell-cmdlets-to-manage-add-ins.md
+++ b/microsoft-365/enterprise/use-the-centralized-deployment-powershell-cmdlets-to-manage-add-ins.md
@@ -42,13 +42,13 @@ Before you can use the Centralized Deployment cmdlets, you need to sign in.
 
 1. Start PowerShell.
 
-2. Connect to PowerShell by using your **User Admin** credentials. Run the following cmdlet.
+2. Connect to PowerShell by using your **Global Admin** credentials. Run the following cmdlet.
 
   ```powershell
   Connect-OrganizationAddInService
   ```
 
-3. In the sign in prompt that opens, select or enter your Microsoft 365 **User Admin** credentials.
+3. In the sign in prompt that opens, select or enter your Microsoft 365 **Global Admin** credentials.
 
 > [!NOTE]
 > For more information about using PowerShell, see [Connect to Microsoft 365 with PowerShell](./connect-to-microsoft-365-powershell.md).


### PR DESCRIPTION
…d-ins.md

User admin is not sufficient to deploy the add-in, either Global Admin or Exchange admin shall be able to deploy. Correct the content to avoid confusion


