### PR TITLE
Fix for manage-creation-of-groups.md

### DIFF
--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -137,7 +137,7 @@ if(!$settingsObjectID)
 }
 
  
-$groupId = (Get-MgBetaGroup | Where-object {$_.displayname -eq $GroupName}).Id
+$groupId = (Get-MgGroup -Filter "displayName eq '$GroupName'").id
 
 $params = @{
 	templateId = "62375ab9-6b52-47ed-826b-58e47e0e304b"


### PR DESCRIPTION
The old code only output a limited paged number of elements if you have a lot of groups. My commit fixes this problem by filtering the output before.


