### PR TITLE
Update password administrator to user administrator

### DIFF
--- a/microsoft-365/admin/add-users/set-password-to-never-expire.md
+++ b/microsoft-365/admin/add-users/set-password-to-never-expire.md
@@ -35,7 +35,7 @@ This article explains how to set a password for an individual user to not expire
 
 ## Before you begin
 
-This article is for people who set password expiration policy for a business, school, or nonprofit. You must be a [global admin or password administrator](about-admin-roles.md) to perform these steps.
+This article is for people who set password expiration policy for a business, school, or nonprofit. You must be a [global admin or user administrator](about-admin-roles.md) to perform these steps.
 
 You can use the Microsoft cloud service [Microsoft Graph Powershell](/powershell/microsoftgraph/overview) to set passwords not to expire for specific users, remove the never-expire configuration or see which users' passwords are set to never expire.
 


### PR DESCRIPTION
Per discussion with PG and also lab test, the "password administrator" role is unable to update the user's password policy while user administrator can.

Refer to the ICM
https://portal.microsofticm.com/imp/v5/incidents/details/577573272/summary?tmpl=UW162p
![image](https://github.com/user-attachments/assets/509a592b-324b-4938-966c-258a6293f2d2)



