### PR TITLE
Update m365-dr-workload-copilot.md

### DIFF
--- a/microsoft-365/enterprise/m365-dr-workload-copilot.md
+++ b/microsoft-365/enterprise/m365-dr-workload-copilot.md
@@ -78,7 +78,7 @@ To find the current location of a user's content of interactions with Microsoft 
 Two people are working together on a Microsoft Word document. User A authored the document and stored it in the OneDrive for Business personal storage site, which is located in France. User B is in Canada and asks Microsoft 365 Copilot to rewrite a paragraph in the document. The paragraph User B submitted as the prompt, as well as the rewrite options Microsoft 365 Copilot provides (the "content of interactions" in this case) are stored in Canada; the original document remains in France, as does any rewrite the user accepts into that document.
 
 **Teams Meeting Experience**
-Microsoft Teams meeting recording video location is determined by the user PDL that starts the recording, or when meetings have an automatic recording policy, the location is determined from the first person joining the meeting. When users in other regions interact with Microsoft 365 Copilot in Teams, those user prompts and corresponding responses are stored in the location of the user that asks the Microsoft 365 Copilot questions.
+Microsoft Teams meeting recording video location is determined by the user PDL that starts the recording, or when meetings have an automatic recording policy, the location is determined by the meeting organiser. When users in other regions interact with Microsoft 365 Copilot in Teams, those user prompts and corresponding responses are stored in the location of the user that asks the Microsoft 365 Copilot questions.
 
 ### Migration and User Experience
 


### PR DESCRIPTION
Teams have moved to a new model where automatic meeting recordings are saved in the meeting organiser's OneDrive and not in the first person joining the meeting OneDrive. This change is effective from ~August 2024. Please ajust accordingly.


