### PR TITLE
Update manage-creation-of-groups.md

### DIFF
--- a/microsoft-365/solutions/manage-creation-of-groups.md
+++ b/microsoft-365/solutions/manage-creation-of-groups.md
@@ -136,7 +136,7 @@ if(!$settingsObjectID)
 }
 
  
-$groupId = (Get-MgBetaGroup | Where-object {$_.displayname -eq $GroupName}).Id
+$groupId = (Get-MgBetaGroup -All | Where-object {$_.displayname -eq $GroupName}).Id
 
 $params = @{
 	templateId = "62375ab9-6b52-47ed-826b-58e47e0e304b"


### PR DESCRIPTION
Added -All parameter to Get-MgBetaGroup in line 29 to prevent the script from only searching the first 100 groups. In large environments, this script won't work otherwise because it can't find the specified Group so GroupCreationAllowedGroupId will remain empty and nobody can create groups.


