### PR TITLE
Update microsoft-365/whiteboard/deploy-on-windows-organizations.md

### DIFF
--- a/microsoft-365/whiteboard/deploy-on-windows-organizations.md
+++ b/microsoft-365/whiteboard/deploy-on-windows-organizations.md
@@ -17,50 +17,17 @@ description: Learn how to deploy Microsoft Whiteboard on devices running Windows
 
 # Deploy Microsoft Whiteboard on Windows 10 devices
 
-Whiteboard can be deployed on devices that run Windows 10 or later using Microsoft Intune or Microsoft Configuration Manager (formerly System Center Configuration Manager). Whiteboard isn't supported on Windows Server.
+Whiteboard can be deployed on devices that run Windows 10 or later using Microsoft Intune. Whiteboard isn't supported on Windows Server.
 
 In order to deploy Whiteboard, you must first ensure that Whiteboard is enabled for your organization. For more information, see [Manage access to Whiteboard](manage-whiteboard-access-organizations.md).
 
 - **Microsoft Intune using an online license mode** – This process allows you to specify groups of users who will receive access to the Whiteboard app.
-
-- **Microsoft Configuration Manager using manual offline installation and updates** – This process allows you to install Whiteboard and then manually update it every 2–4 weeks.
-
->[!NOTE]
-> We recommend using Microsoft Intune. Using Microsoft Configuration Manager requires IT to continuously repackage and install updates to ensure users are running an up-to-date version.
 
 ## Install Whiteboard using Microsoft Intune
 
 1. Add Whiteboard as an available app using the steps in this article: [Add Microsoft Store apps to Microsoft Intune](/mem/intune/apps/store-apps-windows).
 
 2. Assign the app to a group using the steps in this article: [Assign apps to groups with Microsoft Intune](/mem/intune/apps/apps-deploy).
-
-## Install Whiteboard using Microsoft Configuration Manager
-
-1. Using a global administrator account, sign in to the [Microsoft Store for Business](https://businessstore.microsoft.com).
-
-2. In the header, select **Manage**.
-
-3. In the right-hand navigation pane, select **Settings**, and then turn on **Show offline apps**.
-
-4. Wait 10–15 minutes for propagation.
-
-5. Next, go to the [Whiteboard app](https://businessstore.microsoft.com/store/details/microsoft-whiteboard/9mspc6mp8fm4).
-
-6. Select **Get the app**, and then accept the license terms.
-
-7. Go back to the application page.
-
-8. In the **License type** drop-down menu, select **Offline**.
-
-9. Select **Manage**.
-
-10. This action takes you to the inventory management page, which will now offer the option to **Download package for offline use**.
-
-11. Choose the architecture version, and then download it.
-
-12. As soon as you've downloaded the app, you can deploy it through Configuration Manager. To create an update package, follow steps 7–10 to download a newer version and package it for Configuration Manager.
-
-13. For more information, see [Install applications for a device](/mem/configmgr/apps/deploy-use/install-app-for-device).
 
 ## See also
 


### PR DESCRIPTION
Based on https://learn.microsoft.com/en-us/lifecycle/announcements/microsoft-store-for-business-education-retiring the Microsoft Store for Business and Education has been deprecated. This means that on https://learn.microsoft.com/en-us/microsoft-365/whiteboard/deploy-on-windows-organizations?view=o365-worldwide#see-also the section on Microsoft Configuration Manager can be removed.


