### PR TITLE
Update OneDrive/SharePoint maximum path character limit

### DIFF
--- a/microsoft-365/admin/manage/change-address-contact-and-more.md
+++ b/microsoft-365/admin/manage/change-address-contact-and-more.md
@@ -66,7 +66,7 @@ To change information on your organization's profile page, use the following ste
 4. Update your organization's information, then select **Save**. You must fill in all required fields marked with an asterisk (*) before you can save your changes.
 
 > [!NOTE]
-> SharePoint Online and OneDrive have a 256-character limit on Windows PCs. If you exceed the character limit, you receive an error message when you try to do anything within the synchronized document libraries, like creating folders or renaming documents.
+> SharePoint Online and OneDrive enforce a 247-character maximum path length on Windows devices. If you exceed the character limit, you receive an error message when you try to do anything within the synchronized document libraries, like creating folders or renaming documents.
 
 ### What do the organization information fields mean?
 


### PR DESCRIPTION
This should be 247-character limit. Please try creating a file or folder with a path limit of more than 247 characters on your own Windows computer with OneDrive KFM enabled to see this behavior. I can submit a video of this behavior if needed.

Additionally, the sentence could be more descriptive to include maximum path length since that is what is being affected.


