### PR TITLE
Fix Typo In convert-user-mailbox-to-shared-mailbox.md

### DIFF
--- a/microsoft-365/admin/email/convert-user-mailbox-to-shared-mailbox.md
+++ b/microsoft-365/admin/email/convert-user-mailbox-to-shared-mailbox.md
@@ -51,7 +51,7 @@ When you convert a user's mailbox to a shared mailbox, all of the existing email
 
 - To put an In-Place Hold or a Litigation Hold on a shared mailbox, you must assign an Exchange Online Plan 2 license *or* an Exchange Online Plan 1 license and an Exchange Online Archiving add-on license to the shared mailbox.
 
-## Convert a private mailbox to a shared maailbox
+## Convert a private mailbox to a shared mailbox
 
 1. In the admin center, go to the **Users** \> <a href="https://go.microsoft.com/fwlink/p/?linkid=834822" target="_blank">Active users</a> page.
 
@@ -105,4 +105,4 @@ For more info about converting a user mailbox to a shared mailbox in an Exchange
 
 [About shared mailboxes](about-shared-mailboxes.md) (article)\
 [Create a shared mailbox](create-a-shared-mailbox.md) (article)\
-[Configure a shared mailbox](configure-a-shared-mailbox.md) (article)\
+[Configure a shared mailbox](configure-a-shared-mailbox.md) (article)


### PR DESCRIPTION
- Fix typo of `maailbox -> mailbox` in a title header
- Remove extra `\` at end of document