### PR TITLE
Update "Agents by Platforms" list to reflect current agent creation platforms

### DIFF
--- a/microsoft-365/admin/manage/agent-365-overview.md
+++ b/microsoft-365/admin/manage/agent-365-overview.md
@@ -72,8 +72,10 @@ Detailed insights into how agents are distributed and used, helping administrato
 
 - **Agents by Platforms** - Shows which creation platforms are most used for building agents. For example:
 
-  - Copilot Studio (Full/Lite).
-  - Azure AI Foundry.
+  - M365 Copilot Agent Builder.
+  - M365 Agents Toolkit.
+  - Copilot Studio.
+  - Microsoft Foundry.
   - Any external partner platforms.
 
 - **Active Users Over Time** - A trend chart showing daily active user engagement with agents over the past 30 days. Reveals adoption momentum and helps spot usage spikes or declines.


### PR DESCRIPTION
## Summary
Updates the **Agent Analytics > Agents by Platforms** list in `microsoft-365/admin/manage/agent-365-overview.md` to reflect current agent creation platforms.

### Replaced
- Copilot Studio (Full/Lite).
- Azure AI Foundry.
- Any external partner platforms.

### With
- M365 Copilot Agent Builder.
- M365 Agents Toolkit.
- Copilot Studio.
- Microsoft Foundry. (Formerly Azure AI Foundry)
- Any external partner platforms.

## Why
- Adds missing platforms: **M365 Copilot Agent Builder** and **M365 Agents Toolkit**.
- Reflects rebrand from **Azure AI Foundry** to **Microsoft Foundry**.
-  **Copilot Studio Lite** has been renamed again to M365 Agent Builder. **Copilot Studio** is the previous **Copilot Studio (Full)**